### PR TITLE
Pandas Executor and Interestingness Bugfix

### DIFF
--- a/lux/action/Correlation.py
+++ b/lux/action/Correlation.py
@@ -38,7 +38,21 @@ def correlation(ldf:LuxDataFrame,ignoreTranspose:bool=False):
 	# if (ignoreIdentity): vc = filter(lambda x: x.specLst[0].attribute!=x.specLst[1].attribute,ldf.viewCollection)
 	vc = Compiler.compile(ldf, vc, enumerateCollection=False)
 
+	#for benchmarking executor
+	if ldf.toggleBenchmarking == True:
+		ticExec = time.perf_counter()
 	ldf.executor.execute(vc,ldf)
+	if ldf.toggleBenchmarking == True:
+		import pandas as pd
+		tocExec = time.perf_counter()
+		benchmarkData = {'action': ['correlation'], 'executor_type': [ldf.executorType], 'action_phase': ['viewcollection_execution'], 'time': [tocExec-ticExec]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
+	recommendation["collection"] = vc
+
+	#for benchmarking interestingness calculation
+	if ldf.toggleBenchmarking == True:
+		ticInt = time.perf_counter()
 	# Then use the data populated in the view collection to compute score
 	for view in vc:
 		measures = view.getAttrByDataModel("measure")
@@ -54,6 +68,11 @@ def correlation(ldf:LuxDataFrame,ignoreTranspose:bool=False):
 			view.score = interestingness(view,ldf)
 		else:
 			view.score = -1
+	if ldf.toggleBenchmarking == True:
+		tocInt = time.perf_counter()
+		benchmarkData = {'action': ['correlation'], 'executor_type': [ldf.executorType], 'action_phase': ['interestingness_scoring'], 'time': [tocInt-ticInt]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	vc = vc.topK(15)
 	vc.sort(removeInvalid=True)
 	ldf.clearContext()
@@ -61,9 +80,8 @@ def correlation(ldf:LuxDataFrame,ignoreTranspose:bool=False):
 
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
-		import pandas as pd
 		toc = time.perf_counter()
-		benchmarkData = {'action': ['correlation'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = {'action': ['correlation'], 'executor_type': [ldf.executorType], 'action_phase':['entire_action'],'time': [toc-tic]}
 		benchmarkData = pd.DataFrame(data = benchmarkData)
 		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Correlation.py
+++ b/lux/action/Correlation.py
@@ -61,8 +61,11 @@ def correlation(ldf:LuxDataFrame,ignoreTranspose:bool=False):
 
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
+		import pandas as pd
 		toc = time.perf_counter()
-		print(f"Performed correlation action in {toc - tic:0.4f} seconds")
+		benchmarkData = {'action': ['correlation'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation
 
 def checkTransposeNotComputed(ldf,a,b):

--- a/lux/action/Distribution.py
+++ b/lux/action/Distribution.py
@@ -41,9 +41,28 @@ def distribution(ldf,dataTypeConstraint="quantitative"):
 						   "description":"Show bar chart distributions of different attributes in the dataset."}
 
 	vc = ldf.viewCollection
+	#for benchmarking executor
+	if ldf.toggleBenchmarking == True:
+		ticExec = time.perf_counter()
 	ldf.executor.execute(vc,ldf)
+	if ldf.toggleBenchmarking == True:
+		import pandas as pd
+		tocExec = time.perf_counter()
+		benchmarkData = {'action': ['distribution'], 'executor_type': [ldf.executorType], 'action_phase': ['viewcollection_execution'], 'time': [tocExec-ticExec]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
+	recommendation["collection"] = vc
+
+	#for benchmarking interestingness
+	if ldf.toggleBenchmarking == True:
+		ticInt = time.perf_counter()
 	for view in vc:
 		view.score = interestingness(view,ldf)
+	if ldf.toggleBenchmarking == True:
+		tocInt = time.perf_counter()
+		benchmarkData = {'action': ['distribution'], 'executor_type': [ldf.executorType], 'action_phase': ['interestingness_scoring'], 'time': [tocInt-ticInt]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 
 	vc.sort()
 	ldf.clearContext()
@@ -52,9 +71,8 @@ def distribution(ldf,dataTypeConstraint="quantitative"):
 
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
-		import pandas as pd
 		toc = time.perf_counter()
-		benchmarkData = {'action': ['distribution'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = {'action': ['distribution'], 'executor_type': [ldf.executorType], 'action_phase':['entire_action'],'time': [toc-tic]}
 		benchmarkData = pd.DataFrame(data = benchmarkData)
 		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Distribution.py
+++ b/lux/action/Distribution.py
@@ -52,6 +52,9 @@ def distribution(ldf,dataTypeConstraint="quantitative"):
 
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
+		import pandas as pd
 		toc = time.perf_counter()
-		print(f"Performed distribution action in {toc - tic:0.4f} seconds")
+		benchmarkData = {'action': ['distribution'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Enhance.py
+++ b/lux/action/Enhance.py
@@ -46,11 +46,28 @@ def enhance(ldf):
 	vc = lux.view.ViewCollection.ViewCollection(output)
 	vc = Compiler.compile(ldf,vc,enumerateCollection=False)
 	
+	#for benchmarking executor
+	if ldf.toggleBenchmarking == True:
+		ticExec = time.perf_counter()
 	ldf.executor.execute(vc,ldf)
-		
-	# Then use the data populated in the view collection to compute score
+	if ldf.toggleBenchmarking == True:
+		import pandas as pd
+		tocExec = time.perf_counter()
+		benchmarkData = {'action': ['enhance'], 'executor_type': [ldf.executorType], 'action_phase': ['viewcollection_execution'], 'time': [tocExec-ticExec]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
+	recommendation["collection"] = vc
+
+	#for benchmarking interestingness
+	if ldf.toggleBenchmarking == True:
+		ticInt = time.perf_counter()
 	for view in vc:
 		view.score = interestingness(view,ldf)
+	if ldf.toggleBenchmarking == True:
+		tocInt = time.perf_counter()
+		benchmarkData = {'action': ['enhance'], 'executor_type': [ldf.executorType], 'action_phase': ['interestingness_scoring'], 'time': [tocInt-ticInt]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 		# TODO: if (ldf.dataset.cardinality[cVar]>10): score is -1. add in interestingness
 	
 	vc = vc.topK(10)
@@ -58,9 +75,8 @@ def enhance(ldf):
 	recommendation["collection"] = vc
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
-		import pandas as pd
 		toc = time.perf_counter()
-		benchmarkData = {'action': ['enhance'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = {'action': ['enhance'], 'executor_type': [ldf.executorType], 'action_phase':['entire_action'],'time': [toc-tic]}
 		benchmarkData = pd.DataFrame(data = benchmarkData)
 		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Enhance.py
+++ b/lux/action/Enhance.py
@@ -58,6 +58,9 @@ def enhance(ldf):
 	recommendation["collection"] = vc
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
+		import pandas as pd
 		toc = time.perf_counter()
-		print(f"Performed enhance action in {toc - tic:0.4f} seconds")
+		benchmarkData = {'action': ['enhance'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Filter.py
+++ b/lux/action/Filter.py
@@ -68,18 +68,36 @@ def filter(ldf):
 	vc = lux.view.ViewCollection.ViewCollection(output)
 	vc = Compiler.compile(ldf,vc,enumerateCollection=False)
 	
+	#for benchmarking executor
+	if ldf.toggleBenchmarking == True:
+		ticExec = time.perf_counter()
 	ldf.executor.execute(vc,ldf)
+	if ldf.toggleBenchmarking == True:
+		import pandas as pd
+		tocExec = time.perf_counter()
+		benchmarkData = {'action': ['filter'], 'executor_type': [ldf.executorType], 'action_phase': ['viewcollection_execution'], 'time': [tocExec-ticExec]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
+	recommendation["collection"] = vc
+
+	#for benchmarking interestingness
+	if ldf.toggleBenchmarking == True:
+		ticInt = time.perf_counter()
 	for view in vc:
 		view.score = interestingness(view,ldf)
+	if ldf.toggleBenchmarking == True:
+		tocInt = time.perf_counter()
+		benchmarkData = {'action': ['filter'], 'executor_type': [ldf.executorType], 'action_phase': ['interestingness_scoring'], 'time': [tocInt-ticInt]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	vc = vc.topK(10)
 	vc.sort(removeInvalid=True)
 	recommendation["collection"] = vc
 	
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
-		import pandas as pd
 		toc = time.perf_counter()
-		benchmarkData = {'action': ['filter'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = {'action': ['filter'], 'executor_type': [ldf.executorType],'action_phase':['entire_action'], 'time': [toc-tic]}
 		benchmarkData = pd.DataFrame(data = benchmarkData)
 		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Filter.py
+++ b/lux/action/Filter.py
@@ -77,6 +77,9 @@ def filter(ldf):
 	
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
+		import pandas as pd
 		toc = time.perf_counter()
-		print(f"Performed filter action in {toc - tic:0.4f} seconds")
+		benchmarkData = {'action': ['filter'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Generalize.py
+++ b/lux/action/Generalize.py
@@ -70,6 +70,9 @@ def generalize(ldf):
 	vc.sort(removeInvalid=True)
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
+		import pandas as pd
 		toc = time.perf_counter()
-		print(f"Performed generalize action in {toc - tic:0.4f} seconds")
+		benchmarkData = {'action': ['generalize'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/action/Generalize.py
+++ b/lux/action/Generalize.py
@@ -62,17 +62,35 @@ def generalize(ldf):
 		
 	vc = lux.view.ViewCollection.ViewCollection(output)
 	vc = Compiler.compile(ldf,vc,enumerateCollection=False)
+
+	#for benchmarking executor
+	if ldf.toggleBenchmarking == True:
+		ticExec = time.perf_counter()
 	ldf.executor.execute(vc,ldf)
+	if ldf.toggleBenchmarking == True:
+		tocExec = time.perf_counter()
+		benchmarkData = {'action': ['generalize'], 'executor_type': [ldf.executorType], 'action_phase': ['viewcollection_execution'], 'time': [tocExec-ticExec]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	recommendation["collection"] = vc
+
+	#for benchmarking interestingness
+	if ldf.toggleBenchmarking == True:
+		ticInt = time.perf_counter()
 	for view in vc:
 		view.score = interestingness(view,ldf)
+	if ldf.toggleBenchmarking == True:
+		tocInt = time.perf_counter()
+		benchmarkData = {'action': ['generalize'], 'executor_type': [ldf.executorType], 'action_phase': ['interestingness_scoring'], 'time': [tocInt-ticInt]}
+		benchmarkData = pd.DataFrame(data = benchmarkData)
+		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	vc = vc.topK(10)
 	vc.sort(removeInvalid=True)
 	#for benchmarking
 	if ldf.toggleBenchmarking == True:
 		import pandas as pd
 		toc = time.perf_counter()
-		benchmarkData = {'action': ['generalize'], 'executor_type': [ldf.executorType], 'time': [toc-tic]}
+		benchmarkData = {'action': ['generalize'], 'executor_type': [ldf.executorType], 'action_phase':['entire_action'],'time': [toc-tic]}
 		benchmarkData = pd.DataFrame(data = benchmarkData)
 		benchmarkData.to_csv('C:\\Users\\thyne\\Documents\\GitHub\\thyne-lux\\lux\\data\\action_benchmarking.csv', mode = 'a', header = False)
 	return recommendation

--- a/lux/data/action_benchmarking.csv
+++ b/lux/data/action_benchmarking.csv
@@ -1,0 +1,7 @@
+﻿,Action,Executor_Type,Time
+0,correlation,SQL,2.4661208
+0,distribution,SQL,0.2933599
+0,distribution,SQL,0.3674615
+0,enhance,SQL,0.9586182
+0,filter,SQL,14.2751851
+0,generalize,SQL,0.1319494

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -95,7 +95,7 @@ class PandasExecutor(Executor):
                 # For filtered aggregation that have missing groupby-attribute values, set these aggregated value as 0, since no datapoints
                 for vals in allAttrVals:
                     if (vals not in resultVals):
-                        view.data.loc[len(view.data)] = [vals,0]
+                        view.data.loc[len(view.data)] = [vals]+[0]*(len(view.data.columns)-1)
             assert len(list(view.data[groupbyAttr.attribute])) == len(allAttrVals), f"Aggregated data missing values compared to original range of values of `{groupbyAttr.attribute}`." 
             view.data = view.data.sort_values(by=groupbyAttr.attribute, ascending=True)
             view.data = view.data.reset_index()

--- a/lux/executor/SQLExecutor.py
+++ b/lux/executor/SQLExecutor.py
@@ -6,7 +6,6 @@ from lux.executor.Executor import Executor
 from lux.utils import utils
 import math
 
-import time
 class SQLExecutor(Executor):
     def __init__(self):
         self.name = "Executor"
@@ -48,15 +47,9 @@ class SQLExecutor(Executor):
                 data = pd.read_sql(query, ldf.SQLconnection)
                 view.data = utils.pandasToLux(data)
             if (view.mark =="bar" or view.mark =="line"):
-                #tic = time.perf_counter()
                 SQLExecutor.executeAggregate(view, ldf)
-                #toc = time.perf_counter()
-                #print(f"Retrieved aggregate data for bar/line chart in {toc - tic:0.4f} seconds")
             elif (view.mark =="histogram"):
-                #tic = time.perf_counter()
                 SQLExecutor.executeBinning(view, ldf)
-                #toc = time.perf_counter()
-                #print(f"Retrieved binned data for histogram chart in {toc - tic:0.4f} seconds")
 
     @staticmethod
     def executeAggregate(view:View, ldf:LuxDataFrame):

--- a/lux/interestingness/interestingness.py
+++ b/lux/interestingness/interestingness.py
@@ -124,6 +124,8 @@ def deviationFromOverall(view:View,ldf:LuxDataFrame,filterSpecs:list,msrAttribut
 	
 	v = unfilteredView.data[msrAttribute]
 	v = v/v.sum()  
+	if len(v) != len(v_filter):
+		v_filter = v_filter.sample(len(v), replace = True)
 	assert len(v) == len(v_filter), "Data for filtered and unfiltered view have unequal length." 
 	sig = v_filter_size/v_size #significance factor
 	# Euclidean distance as L2 function

--- a/lux/luxDataFrame/LuxDataframe.py
+++ b/lux/luxDataFrame/LuxDataframe.py
@@ -178,7 +178,9 @@ class LuxDataFrame(pd.DataFrame):
     #######################################################
     ########## SQL Metadata, type, model schema ###########
     #######################################################
-
+    def setDBConnection(self, connection, t_name):
+        if str(type(connection)) == "<class 'psycopg2.extensions.connection'>":
+            self.setSQLConnection(connection, t_name)
     def setSQLConnection(self, connection, t_name):
         #for benchmarking
         if self.toggleBenchmarking == True:


### PR DESCRIPTION
When dealing with filtered aggregation with missing groupby-attribute values, issue in cases where more than 1 aggregated value which caused a column mismatch. Executor now handles this case appropriately.

Issue in interestingness function where v_filter and v are of different lengths, now samples v_filter to make it the same size and the unfiltered value set