### PR TITLE
Generalize Action Bug Fix, Copy VisSpec List bugfix

### DIFF
--- a/lux/luxDataFrame/LuxDataframe.py
+++ b/lux/luxDataFrame/LuxDataframe.py
@@ -56,7 +56,7 @@ class LuxDataFrame(pd.DataFrame):
         elif (type.lower()=="pandas"):
             self.default_pandas_view = True
         else: 
-            warnings.warn("Unsupported display type. Default display option should either be `lux` or `pandas`.",stacklevel=2)
+            warnings.warn("Unsupported display type. Default display option should either be `lux` or `pandas`.")
     # @property
     # def context(self):
     #     return self.context
@@ -134,8 +134,6 @@ class LuxDataFrame(pd.DataFrame):
         -----
             :doc:`../guide/spec`
         """        
-        if type(context)!=list:
-            raise TypeError("Input context must be a list consisting of string descriptions or lux.VisSpec objects. \nSee more at: https://lux-api.readthedocs.io/en/dfapi/source/guide/spec.html")
         self.context = context
         self._refresh_context()
     def set_context_as_vis(self,vis:Vis):
@@ -207,7 +205,7 @@ class LuxDataFrame(pd.DataFrame):
             elif pd.api.types.is_datetime64_any_dtype(self.dtypes[attr]) or pd.api.types.is_period_dtype(self.dtypes[attr]): #check if attribute is any type of datetime dtype
                 self.data_type_lookup[attr] = "temporal"
         # for attr in list(df.dtypes[df.dtypes=="int64"].keys()):
-        # 	if self.cardinality[attr]>50:
+        #   if self.cardinality[attr]>50:
         self.data_type = self.mapping(self.data_type_lookup)
 
 
@@ -357,14 +355,9 @@ class LuxDataFrame(pd.DataFrame):
         from lux.action.generalize import generalize
 
         self._rec_info = []
-        if (self.current_view is None):
-            no_view = True
-            one_current_view = False
-            multiple_current_views = False
-        else:
-            no_view = len(self.current_view) == 0
-            one_current_view = len(self.current_view) == 1
-            multiple_current_views = len(self.current_view) > 1
+        no_view = len(self.current_view) == 0
+        one_current_view = len(self.current_view) == 1
+        multiple_current_views = len(self.current_view) > 1
 
         if (no_view):
             self._rec_info.append(correlation(self))
@@ -422,13 +415,11 @@ class LuxDataFrame(pd.DataFrame):
             When all the exported vis is from the same tab, return a VisCollection of selected views. -> VisCollection(v1, v2...)
             When the exported vis is from the different tabs, return a dictionary with the action name as key and selected views in the VisCollection. -> {"Enhance": VisCollection(v1, v2...), "Filter": VisCollection(v5, v7...), ..}
         """        
-        if (self.widget is None):
-            warnings.warn("No widget attached to the dataframe. Please assign widget to an output variable.", stacklevel=2)
         exported_vis_lst =self.widget._exportedVisIdxs
         exported_views = [] 
         if (exported_vis_lst=={}):
             import warnings
-            warnings.warn("No visualization selected to export",stacklevel=2)
+            warnings.warn("No visualization selected to export")
             return []
         if len(exported_vis_lst) == 1 and "currentView" in exported_vis_lst:
             return self.current_view
@@ -445,18 +436,14 @@ class LuxDataFrame(pd.DataFrame):
             exported_views = VisCollection(list(map(self.recommendation[export_action].__getitem__, exported_vis_lst[export_action])))
             return exported_views
         else:
-            warnings.warn("No visualization selected to export",stacklevel=2)
+            import warnings
+            warnings.warn("No visualization selected to export")
             return []
 
     def _repr_html_(self):
         from IPython.display import display
         from IPython.display import clear_output
         import ipywidgets as widgets
-        
-        if (type(self.index) != pd.core.indexes.range.RangeIndex):# if multi-index, then default to pandas output
-            warnings.warn("\n Lux does not currently support dataframes with hierarchical indexes. \n Please convert the dataframe into a flat table via `pandas.DataFrame.reset_index`.",stacklevel=2)
-            display(self.display_pandas())
-            return
         self.toggle_pandas_view = self.default_pandas_view # Reset to Pandas View everytime
         # Ensure that metadata is recomputed before plotting recs (since dataframe operations do not always go through init or _refresh_context)
         if self.executor_type == "Pandas":
@@ -530,11 +517,9 @@ class LuxDataFrame(pd.DataFrame):
 
     def to_JSON(self, input_current_view=""):
         widget_spec = {}
-        if (self.current_view): 
-            self.executor.execute(self.current_view, self)
-            widget_spec["current_view"] = LuxDataFrame.current_view_to_JSON(self.current_view, input_current_view)
-        else:
-            widget_spec["current_view"] = {}
+        self.executor.execute(self.current_view, self)
+        widget_spec["current_view"] = LuxDataFrame.current_view_to_JSON(self.current_view, input_current_view)
+        
         widget_spec["recommendation"] = []
         
         # Recommended Collection

--- a/lux/luxDataFrame/LuxDataframe.py
+++ b/lux/luxDataFrame/LuxDataframe.py
@@ -45,7 +45,6 @@ class LuxDataFrame(pd.DataFrame):
     def set_default_display(self, type:str) -> None:
         """
         Set the widget display to show Pandas by default or Lux by default
-
         Parameters
         ----------
         type : str
@@ -56,7 +55,7 @@ class LuxDataFrame(pd.DataFrame):
         elif (type.lower()=="pandas"):
             self.default_pandas_view = True
         else: 
-            warnings.warn("Unsupported display type. Default display option should either be `lux` or `pandas`.")
+            warnings.warn("Unsupported display type. Default display option should either be `lux` or `pandas`.",stacklevel=2)
     # @property
     # def context(self):
     #     return self.context
@@ -78,7 +77,6 @@ class LuxDataFrame(pd.DataFrame):
         """
         Modify plot aesthetic settings to all Views in the dataframe display
         Currently only supported for Altair visualizations
-
         Parameters
         ----------
         config_func : typing.Callable
@@ -87,7 +85,6 @@ class LuxDataFrame(pd.DataFrame):
         Example
         ----------
         Changing the color of marks and adding a title for all charts displayed for this dataframe
-
         >>> df = pd.read_csv("lux/data/car.csv")
         >>> def changeColorAddTitle(chart):
                 chart = chart.configure_mark(color="red") # change mark color to red
@@ -95,7 +92,6 @@ class LuxDataFrame(pd.DataFrame):
                 return chart
         >>> df.set_plot_config(changeColorAddTitle)
         >>> df
-
         Change the opacity of all scatterplots displayed for this dataframe
         >>> df = pd.read_csv("lux/data/olympic.csv")
         >>> def changeOpacityScatterOnly(chart):
@@ -124,22 +120,21 @@ class LuxDataFrame(pd.DataFrame):
         """
         Main function to set the context of the dataframe.
         The context input goes through the parser, so that the string inputs are parsed into a lux.VisSpec object.
-
         Parameters
         ----------
         context : typing.List[str,VisSpec]
             Context list, can be a mix of string shorthand or a lux.VisSpec object
-
         Notes
         -----
             :doc:`../guide/spec`
         """        
+        if type(context)!=list:
+            raise TypeError("Input context must be a list consisting of string descriptions or lux.VisSpec objects. \nSee more at: https://lux-api.readthedocs.io/en/dfapi/source/guide/spec.html")
         self.context = context
         self._refresh_context()
     def set_context_as_vis(self,vis:Vis):
         """
         Set context of the dataframe as the View
-
         Parameters
         ----------
         view : View
@@ -154,7 +149,6 @@ class LuxDataFrame(pd.DataFrame):
             temp_spec = spec.copy_spec()
             output.append(temp_spec)
         return(output)
-
     def clear_context(self):
         self.context = []
         self.current_view = []
@@ -355,9 +349,14 @@ class LuxDataFrame(pd.DataFrame):
         from lux.action.generalize import generalize
 
         self._rec_info = []
-        no_view = len(self.current_view) == 0
-        one_current_view = len(self.current_view) == 1
-        multiple_current_views = len(self.current_view) > 1
+        if (self.current_view is None):
+            no_view = True
+            one_current_view = False
+            multiple_current_views = False
+        else:
+            no_view = len(self.current_view) == 0
+            one_current_view = len(self.current_view) == 1
+            multiple_current_views = len(self.current_view) > 1
 
         if (no_view):
             self._rec_info.append(correlation(self))
@@ -400,7 +399,6 @@ class LuxDataFrame(pd.DataFrame):
     def get_exported(self) -> typing.Union[typing.Dict[str,VisCollection], VisCollection]:
         """
         Get selected views as exported View Collection
-
         Notes
         -----
         Convert the _exportedVisIdxs dictionary into a programmable VisCollection
@@ -415,11 +413,13 @@ class LuxDataFrame(pd.DataFrame):
             When all the exported vis is from the same tab, return a VisCollection of selected views. -> VisCollection(v1, v2...)
             When the exported vis is from the different tabs, return a dictionary with the action name as key and selected views in the VisCollection. -> {"Enhance": VisCollection(v1, v2...), "Filter": VisCollection(v5, v7...), ..}
         """        
+        if (self.widget is None):
+            warnings.warn("No widget attached to the dataframe. Please assign widget to an output variable.", stacklevel=2)
         exported_vis_lst =self.widget._exportedVisIdxs
         exported_views = [] 
         if (exported_vis_lst=={}):
             import warnings
-            warnings.warn("No visualization selected to export")
+            warnings.warn("No visualization selected to export",stacklevel=2)
             return []
         if len(exported_vis_lst) == 1 and "currentView" in exported_vis_lst:
             return self.current_view
@@ -436,14 +436,18 @@ class LuxDataFrame(pd.DataFrame):
             exported_views = VisCollection(list(map(self.recommendation[export_action].__getitem__, exported_vis_lst[export_action])))
             return exported_views
         else:
-            import warnings
-            warnings.warn("No visualization selected to export")
+            warnings.warn("No visualization selected to export",stacklevel=2)
             return []
 
     def _repr_html_(self):
         from IPython.display import display
         from IPython.display import clear_output
         import ipywidgets as widgets
+        
+        if (type(self.index) != pd.core.indexes.range.RangeIndex):# if multi-index, then default to pandas output
+            warnings.warn("\n Lux does not currently support dataframes with hierarchical indexes. \n Please convert the dataframe into a flat table via `pandas.DataFrame.reset_index`.",stacklevel=2)
+            display(self.display_pandas())
+            return
         self.toggle_pandas_view = self.default_pandas_view # Reset to Pandas View everytime
         # Ensure that metadata is recomputed before plotting recs (since dataframe operations do not always go through init or _refresh_context)
         if self.executor_type == "Pandas":
@@ -517,9 +521,11 @@ class LuxDataFrame(pd.DataFrame):
 
     def to_JSON(self, input_current_view=""):
         widget_spec = {}
-        self.executor.execute(self.current_view, self)
-        widget_spec["current_view"] = LuxDataFrame.current_view_to_JSON(self.current_view, input_current_view)
-        
+        if (self.current_view): 
+            self.executor.execute(self.current_view, self)
+            widget_spec["current_view"] = LuxDataFrame.current_view_to_JSON(self.current_view, input_current_view)
+        else:
+            widget_spec["current_view"] = {}
         widget_spec["recommendation"] = []
         
         # Recommended Collection
@@ -551,5 +557,3 @@ class LuxDataFrame(pd.DataFrame):
                 # delete DataObjectCollection since not JSON serializable
                 del rec_lst[idx]["collection"]
         return rec_lst
-
-

--- a/lux/vis/Vis.py
+++ b/lux/vis/Vis.py
@@ -32,7 +32,7 @@ class Vis:
 			if hasattr(spec,"attribute"):
 				if spec.attribute != "":
 					if spec.aggregation != "":
-						attribute = spec._aggregation_name.upper() + "(" + spec.attribute + ")"
+						attribute = spec.aggregation.upper() + "(" + spec.attribute + ")"
 					elif spec.bin_size > 0:
 						attribute = "BIN(" + spec.attribute + ")"
 					else:

--- a/lux/vis/Vis.py
+++ b/lux/vis/Vis.py
@@ -32,7 +32,7 @@ class Vis:
 			if hasattr(spec,"attribute"):
 				if spec.attribute != "":
 					if spec.aggregation != "":
-						attribute = spec.aggregation.upper() + "(" + spec.attribute + ")"
+						attribute = spec._aggregation_name.upper() + "(" + spec.attribute + ")"
 					elif spec.bin_size > 0:
 						attribute = "BIN(" + spec.attribute + ")"
 					else:

--- a/lux/vis/VisSpec.py
+++ b/lux/vis/VisSpec.py
@@ -30,7 +30,7 @@ class VisSpec:
 			Possible values: 'dimension', 'measure', by default ""
 		aggregation : str, optional
 			Aggregation function for specified attribute, by default ""
-			Possible values: 'sum','mean', and others supported by Pandas.aggregate (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.aggregate.html), including numpy aggregation functions (e.g., np.ptp), by default ""
+			Possible values: 'sum','mean', and others supported by Pandas.aggregate (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.aggregate.html), by default ""
 		bin_size : int, optional
 			Number of bins for histograms, by default 0
 		weight : float, optional
@@ -55,12 +55,33 @@ class VisSpec:
 		self.weight = weight
 		self.sort = sort
 		self.exclude = exclude
+
 		# If aggregation input is a function (e.g., np.std), get the string name of the function for plotting
 		if hasattr(self.aggregation,'__name__'): 
 			self._aggregation_name = self.aggregation.__name__
 		else:
 			self._aggregation_name = self.aggregation
-			
+
+	def copy_spec(self):
+		description_copy = self.description
+		# Description gets compiled to attribute, value, filter_op
+		attribute_copy = self.attribute
+		value_copy = self.value
+		filter_op_copy = self.filter_op
+		# self.parseDescription()
+		# Properties
+		channel_copy = self.channel
+		data_type_copy = self.data_type
+		data_model_copy = self.data_model
+		aggregation_copy = self.aggregation
+		bin_size_copy = self.bin_size
+		weight_copy = self.weight
+		sort_copy = self.sort
+		exclude_copy = self.exclude
+
+		copied_spec = VisSpec(description = description_copy, attribute = attribute_copy, value = value_copy, filter_op = filter_op_copy, channel = channel_copy, data_type = data_type_copy, data_model = data_model_copy, aggregation = aggregation_copy, bin_size = bin_size_copy, weight = weight_copy, sort = sort_copy, exclude = exclude_copy)
+		return copied_spec
+
 	def __repr__(self):
 		attributes = []
 		if self.description != "":

--- a/lux/vis/VisSpec.py
+++ b/lux/vis/VisSpec.py
@@ -63,24 +63,9 @@ class VisSpec:
 			self._aggregation_name = self.aggregation
 
 	def copy_spec(self):
-		description_copy = self.description
-		# Description gets compiled to attribute, value, filter_op
-		attribute_copy = self.attribute
-		value_copy = self.value
-		filter_op_copy = self.filter_op
-		# self.parseDescription()
-		# Properties
-		channel_copy = self.channel
-		data_type_copy = self.data_type
-		data_model_copy = self.data_model
-		aggregation_copy = self.aggregation
-		bin_size_copy = self.bin_size
-		weight_copy = self.weight
-		sort_copy = self.sort
-		exclude_copy = self.exclude
-
-		copied_spec = VisSpec(description = description_copy, attribute = attribute_copy, value = value_copy, filter_op = filter_op_copy, channel = channel_copy, data_type = data_type_copy, data_model = data_model_copy, aggregation = aggregation_copy, bin_size = bin_size_copy, weight = weight_copy, sort = sort_copy, exclude = exclude_copy)
-		return copied_spec
+		copied_spec = VisSpec()
+		copied_spec.__dict__ = self.__dict__.copy()    # just a shallow copy
+		return(copied_spec)
 
 	def __repr__(self):
 		attributes = []

--- a/lux/vis/VisSpec.py
+++ b/lux/vis/VisSpec.py
@@ -30,7 +30,7 @@ class VisSpec:
 			Possible values: 'dimension', 'measure', by default ""
 		aggregation : str, optional
 			Aggregation function for specified attribute, by default ""
-			Possible values: 'sum','mean', and others supported by Pandas.aggregate (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.aggregate.html), by default ""
+			Possible values: 'sum','mean', and others supported by Pandas.aggregate (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.aggregate.html), including numpy aggregation functions (e.g., np.ptp), by default ""
 		bin_size : int, optional
 			Number of bins for histograms, by default 0
 		weight : float, optional

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -9,3 +9,19 @@ def test_vary_filter_val():
     df.set_context_as_vis(vis)
     df.show_more()
     assert len(df.recommendation["Filter"]) == len(df["SportType"].unique())-1
+
+#test case for generalize action with more than 2 variables specified in context
+def test_generalize_action():
+	df = pd.read_csv("lux/data/car.csv")
+	df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
+	df.set_context(["Cylinders", "Horsepower", "MilesPerGal"])
+	df.show_more()
+
+	assert len(df.recommendation['Generalize']) == 3
+
+	#check that all graphs are unique
+	spec_lst1 = df.recommendation['Generalize'][0].spec_lst
+	spec_lst2 = df.recommendation['Generalize'][1].spec_lst
+	spec_lst3 = df.recommendation['Generalize'][2].spec_lst
+
+	assert spec_lst1 != spec_lst2 and spec_lst1 != spec_lst3 and spec_lst2 != spec_lst3

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -51,6 +51,7 @@ def test_custom_plot_setting():
 def test_remove():
     from lux.vis.Vis import Vis
     df = pd.read_csv("lux/data/car.csv")
+<<<<<<< HEAD
     vis = Vis([lux.VisSpec("Horsepower"),lux.VisSpec("Acceleration")],df)
     vis.remove_column_from_spec("Horsepower",remove_first=False)
     assert vis.spec_lst[0].attribute == "Acceleration"
@@ -88,3 +89,17 @@ def test_vis_custom_aggregation_as_numpy_func():
     vis = Vis(["HighestDegree",lux.VisSpec("AverageCost",aggregation=np.ptp)],df)
     assert vis.get_attr_by_data_model("measure")[0].aggregation == np.ptp
     assert vis.get_attr_by_data_model("measure")[0]._aggregation_name =='ptp'
+=======
+    view = View(["Horsepower","Horsepower"])
+    view.load(df)
+    view.remove_column_from_spec("Horsepower")
+    assert (view.spec_lst == []),"Remove all instances of Horsepower"
+
+    df = pd.read_csv("lux/data/car.csv")
+    view = View(["Horsepower","Horsepower"])
+    view.load(df)
+    print(len(view.spec_lst))
+    view.remove_column_from_spec("Horsepower",remove_first=True)
+    assert (len(view.spec_lst)==1),"Remove only 1 instances of Horsepower"
+    assert (view.spec_lst[0].attribute=="Horsepower"),"Remove only 1 instances of Horsepower"
+>>>>>>> Merge remove_column functions, Bugfix in Generalize Action, update test_view

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -51,7 +51,6 @@ def test_custom_plot_setting():
 def test_remove():
     from lux.vis.Vis import Vis
     df = pd.read_csv("lux/data/car.csv")
-<<<<<<< HEAD
     vis = Vis([lux.VisSpec("Horsepower"),lux.VisSpec("Acceleration")],df)
     vis.remove_column_from_spec("Horsepower",remove_first=False)
     assert vis.spec_lst[0].attribute == "Acceleration"
@@ -89,17 +88,3 @@ def test_vis_custom_aggregation_as_numpy_func():
     vis = Vis(["HighestDegree",lux.VisSpec("AverageCost",aggregation=np.ptp)],df)
     assert vis.get_attr_by_data_model("measure")[0].aggregation == np.ptp
     assert vis.get_attr_by_data_model("measure")[0]._aggregation_name =='ptp'
-=======
-    view = View(["Horsepower","Horsepower"])
-    view.load(df)
-    view.remove_column_from_spec("Horsepower")
-    assert (view.spec_lst == []),"Remove all instances of Horsepower"
-
-    df = pd.read_csv("lux/data/car.csv")
-    view = View(["Horsepower","Horsepower"])
-    view.load(df)
-    print(len(view.spec_lst))
-    view.remove_column_from_spec("Horsepower",remove_first=True)
-    assert (len(view.spec_lst)==1),"Remove only 1 instances of Horsepower"
-    assert (view.spec_lst[0].attribute=="Horsepower"),"Remove only 1 instances of Horsepower"
->>>>>>> Merge remove_column functions, Bugfix in Generalize Action, update test_view


### PR DESCRIPTION
Issue where copies of LuxDataFrame contexts were not resulting in a list of brand new VisSpecs (resulted in list of references to original VisSpecs). This resulted in issues in the compiler's determine_encoding function. When the compiler would change the encoding of one VisSpec, this also changed the encoding other copies of the VisSpec being used elsewhere.

Bug was happening when more than 2 variables were being specified in a LuxDataFrame's context such as:
`df.set_context(["Cylinders", "Horsepower", "MilesPerGal"])`

Added copy functions to create a true copy of an individual VisSpec and a function to create a copy of a LuxDataFrame's context.