### PR TITLE
Refactor LuxDataframe for more efficient metadata and recommendation maintenance

### DIFF
--- a/doc/source/reference/gen/lux.compiler.Validator.Validator.rst
+++ b/doc/source/reference/gen/lux.compiler.Validator.Validator.rst
@@ -14,7 +14,7 @@ lux.compiler.Validator.Validator
    .. autosummary::
    
       ~Validator.__init__
-      ~Validator.validate_spec
+      ~Validator.validate_intent
    
    
 

--- a/doc/source/reference/gen/lux.luxDataFrame.LuxDataframe.LuxDataFrame.rst
+++ b/doc/source/reference/gen/lux.luxDataFrame.LuxDataframe.LuxDataFrame.rst
@@ -186,7 +186,7 @@ lux.luxDataFrame.LuxDataframe.LuxDataFrame
       ~LuxDataFrame.set_intent_as_vis
       ~LuxDataFrame.set_plot_config
       ~LuxDataFrame.shift
-      ~LuxDataFrame.show_more
+      ~LuxDataFrame.maintain_recs
       ~LuxDataFrame.skew
       ~LuxDataFrame.slice_shift
       ~LuxDataFrame.sort_index

--- a/examples/tutorial/5-datetime.ipynb
+++ b/examples/tutorial/5-datetime.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Working with Dates\n",
     "\n",
-    "This is a tutorial on how to prepare temporal data for use with Lux. To display temporal fields in Lux, the column must be converted into Pandas's [`datetime`](https://docs.python.org/3/library/datetime.html) objects. "
+    "This is a tutorial on how to prepare temporal data for use with Lux. To display temporal fields in Lux, the column must be converted into Pandas's [`datetime`](https://docs.python.org/3/library/datetime.html) objects. Lux automatically detects attribute named as `date`, `month`, `year`, `day`, and `time` as a datetime field and recognizes them as temporal data types. If you're temporal attributes do not have these names, read more to find out how to work with temporal data types in Lux."
    ]
   },
   {
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a toy example, a dataframe might contain a `date` attribute as strings of dates:"
+    "As a toy example, a dataframe might contain a `record_date` attribute as strings of dates:"
    ]
   },
   {
@@ -46,15 +46,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.DataFrame({'date': ['2020-02-01', '2020-03-01', '2020-04-01', '2020-05-01','2020-06-01',],\n",
-    "                   'value': [10.5,15.2,20.3,25.2, 14.2]})"
+    "df = pd.DataFrame({'record_date': ['2020-02-01', '2020-03-01', '2020-04-01', '2020-05-01','2020-06-01',],\n",
+    "                   'value': [10.5,15.2,20.3,25.2, 14.2]})\n",
+    "\n",
+    "df"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, the `date` attribute is detected as an `object` type as Pandas's data type [`dtype`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.dtypes.html):"
+    "By default, the `record_date` attribute is detected as an `object` type as Pandas's data type [`dtype`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.dtypes.html):"
    ]
   },
   {
@@ -70,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since `date` is detected as an object type in Pandas, the `date` field is recognized as a `nominal` field in Lux, instead of a `temporal` field:"
+    "Since `record_date` is detected as an object type in Pandas, the `record_date` field is recognized as a `nominal` field in Lux, instead of a `temporal` field:"
    ]
   },
   {
@@ -95,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vis = Vis([\"date\",\"value\"],df)\n",
+    "vis = Vis([\"record_date\",\"value\"],df)\n",
     "vis"
    ]
   },
@@ -103,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To fix this, we can convert the `date` column into a datetime object by doing:"
+    "To fix this, we can convert the `record_date` column into a datetime object by doing:"
    ]
   },
   {
@@ -112,8 +114,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df['date'] = pd.to_datetime(df['date'],format=\"%Y-%m-%d\")\n",
-    "df['date']"
+    "df[\"record_date\"] = pd.to_datetime(df[\"record_date\"],format=\"%Y-%m-%d\")\n",
+    "df[\"record_date\"]"
    ]
   },
   {
@@ -149,7 +151,7 @@
     "### Advanced Date Manipulation\n",
     "You might notice earlier that all the dates in our example dataset are the first of the month. In this case, there may be situations where we only want to list the year and month, instead of the full date. Here, we look at how to handle these cases.\n",
     "\n",
-    "Below we look at an example stocks dataset that also has `date` field with each row representing data for the first of each month."
+    "Below we look at an example stocks dataset that also has `month_date` field with each row representing data for the first of each month."
    ]
   },
   {
@@ -169,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vis = Vis([\"date\",\"price\"],df)\n",
+    "vis = Vis([\"monthdate\",\"price\"],df)\n",
     "vis"
    ]
   },
@@ -186,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"date\"] = pd.DatetimeIndex(df[\"date\"]).to_period(freq='M')"
+    "df[\"monthdate\"] = pd.DatetimeIndex(df[\"monthdate\"]).to_period(freq='M')"
    ]
   },
   {
@@ -215,7 +217,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[df['date'] == '2008-11']"
+    "df[df[\"monthdate\"] == '2008-11']"
    ]
   },
   {
@@ -231,7 +233,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vis = Vis([\"date=2008-11\",\"price\",\"symbol\"],df)\n",
+    "vis = Vis([\"monthdate=2008-11\",\"price\",\"symbol\"],df)\n",
     "vis"
    ]
   }

--- a/lux/action/column_group.py
+++ b/lux/action/column_group.py
@@ -14,7 +14,10 @@ def column_group(ldf):
 	recommendation = {"action":"Column Groups",
 					"description":"Shows charts of possible visualizations with respect to the column-wise index."}
 	collection = []
-	ldf_flat = ldf.reset_index() #use a single shared ldf_flat so that metadata doesn't need to be computed for every vis
+	ldf_flat = ldf
+	if isinstance(ldf.columns,pd.DatetimeIndex):
+		ldf_flat.columns = ldf_flat.columns.format()
+	ldf_flat = ldf_flat.reset_index() #use a single shared ldf_flat so that metadata doesn't need to be computed for every vis
 	if (ldf.index.nlevels==1):
 		index_column_name = ldf.index.name
 		if isinstance(ldf.columns,pd.DatetimeIndex):

--- a/lux/action/column_group.py
+++ b/lux/action/column_group.py
@@ -14,16 +14,16 @@ def column_group(ldf):
 	recommendation = {"action":"Column Groups",
 					"description":"Shows charts of possible visualizations with respect to the column-wise index."}
 	collection = []
-	data = ldf.copy()
+	ldf_flat = ldf.reset_index() #use a single shared ldf_flat so that metadata doesn't need to be computed for every vis
 	if (ldf.index.nlevels==1):
 		index_column_name = ldf.index.name
 		if isinstance(ldf.columns,pd.DatetimeIndex):
-			data.columns = ldf.columns.to_native_types()
-		for attribute in data.columns:
-			vis = Vis([index_column_name,lux.Clause(str(attribute),aggregation=None)],data[attribute].reset_index())
+			ldf.columns = ldf.columns.to_native_types()
+		for attribute in ldf.columns:
+			vis = Vis([index_column_name,lux.Clause(str(attribute),aggregation=None)],ldf_flat)
 			collection.append(vis)
 	vlst = VisList(collection)
-	# Note that we are not computing interestingness score here because we want to preserve the arrangement of the aggregated data
+	# Note that we are not computing interestingness score here because we want to preserve the arrangement of the aggregated ldf
 	
 	recommendation["collection"] = vlst
 	#for benchmarking

--- a/lux/action/row_group.py
+++ b/lux/action/row_group.py
@@ -27,8 +27,8 @@ def row_group(ldf):
 			# 	rowdf.data_type_lookup["index"]="nominal"
 			# 	rowdf.data_model_lookup["index"]="dimension"
 			# 	rowdf.cardinality["index"]=len(rowdf)
-			if isinstance(ldf.columns,pd.DatetimeIndex):
-				rowdf.data_type_lookup[dim_name]="temporal"
+			# if isinstance(ldf.columns,pd.DatetimeIndex):
+			# 	rowdf.data_type_lookup[dim_name]="temporal"
 			vis = Vis([dim_name,lux.Clause(row.name,aggregation=None)],rowdf)
 			collection.append(vis)
 	vlst = VisList(collection)

--- a/lux/action/univariate.py
+++ b/lux/action/univariate.py
@@ -30,7 +30,7 @@ def univariate(ldf, data_type_constraint="quantitative"):
 	filter_specs = utils.get_filter_specs(ldf._intent)
 	ignore_rec_flag = False
 	if (data_type_constraint== "quantitative"):
-		intent = [lux.Clause("?",data_type="quantitative")]
+		intent = [lux.Clause("?",data_type="quantitative",exclude="Number of Records")]
 		intent.extend(filter_specs)
 		recommendation = {"action":"Distribution",
 						  "description":"Show univariate histograms of <p class='highlight-descriptor'>quantitative</p>  attributes."}

--- a/lux/compiler/Compiler.py
+++ b/lux/compiler/Compiler.py
@@ -115,13 +115,15 @@ class Compiler:
 			vis list with compiled lux.Vis objects.
 		"""		
 		# TODO: copy might not be neccesary
+		from lux.utils.date_utils import is_datetime_string
 		import copy
 		vc = copy.deepcopy(vis_collection)  # Preserve the original dobj
 		for vis in vc:
 			for clause in vis._inferred_intent:
 				if (clause.description == "?"):
 					clause.description = ""
-				if (clause.attribute!="" and clause.attribute!="Record"):
+				# TODO: Note that "and not is_datetime_string(clause.attribute))" is a temporary hack and breaks the `test_row_column_group` example
+				if (clause.attribute!="" and clause.attribute!="Record") and not is_datetime_string(clause.attribute):
 					# if (clause.data_type == ""):
 					clause.data_type = ldf.data_type_lookup[clause.attribute]
 					# if (clause.data_model == ""):

--- a/lux/compiler/Compiler.py
+++ b/lux/compiler/Compiler.py
@@ -123,7 +123,7 @@ class Compiler:
 				if (clause.description == "?"):
 					clause.description = ""
 				# TODO: Note that "and not is_datetime_string(clause.attribute))" is a temporary hack and breaks the `test_row_column_group` example
-				if (clause.attribute!="" and clause.attribute!="Record") and not is_datetime_string(clause.attribute):
+				if (clause.attribute!="" and clause.attribute!="Record"):# and not is_datetime_string(clause.attribute):
 					# if (clause.data_type == ""):
 					clause.data_type = ldf.data_type_lookup[clause.attribute]
 					# if (clause.data_model == ""):

--- a/lux/compiler/Compiler.py
+++ b/lux/compiler/Compiler.py
@@ -41,14 +41,16 @@ class Compiler:
 		vis_collection: list[lux.Vis]
 			vis list with compiled lux.Vis objects.
 		"""
-		if (enumerate_collection):
-			vis_collection = Compiler.enumerate_collection(_inferred_intent,ldf)
-		vis_collection = Compiler.populate_data_type_model(ldf, vis_collection)  # autofill data type/model information
-		if len(vis_collection)>1: 
-			vis_collection = Compiler.remove_all_invalid(vis_collection) # remove invalid visualizations from collection
-		for vis in vis_collection:
-			Compiler.determine_encoding(ldf, vis)  # autofill viz related information
-		return vis_collection
+		if (_inferred_intent):
+			if (enumerate_collection):
+				vis_collection = Compiler.enumerate_collection(_inferred_intent,ldf)
+			vis_collection = Compiler.populate_data_type_model(ldf, vis_collection)  # autofill data type/model information
+			if len(vis_collection)>1: 
+				vis_collection = Compiler.remove_all_invalid(vis_collection) # remove invalid visualizations from collection
+			for vis in vis_collection:
+				Compiler.determine_encoding(ldf, vis)  # autofill viz related information
+			ldf._compiled=True
+			return vis_collection
 
 	@staticmethod
 	def enumerate_collection(_inferred_intent:List[Clause],ldf: LuxDataFrame) -> VisList:

--- a/lux/compiler/Validator.py
+++ b/lux/compiler/Validator.py
@@ -13,7 +13,7 @@ class Validator:
 		return f"<Validator>"
 
 	@staticmethod
-	def validate_spec(intent: List[Clause], ldf:LuxDataFrame) -> None:
+	def validate_intent(intent: List[Clause], ldf:LuxDataFrame) -> None:
 		"""
 		Validates input specifications from the user to find inconsistencies and errors.
 
@@ -31,46 +31,30 @@ class Validator:
 		ValueError
 			Ensures no input intent are consistent with DataFrame.
 		"""
-		unique_vals = ldf.unique_values
-		print_warning = False
 
-		def exists_in_df(value, unique_values):
-			return any(value in unique_values[vals] for vals in unique_values)
-
-		def validate_attr(clause):
+		def validate_clause(clause):
 			if not((clause.attribute and clause.attribute == "?") or (clause.value and clause.value=="?")):
 				if isinstance(clause.attribute,list):
-					check_attr_exists_group = all(attr in list(ldf.columns) for attr in clause.attribute)
-					if clause.attribute and not check_attr_exists_group:
-						print_warning = True
+					for attr in clause.attribute:
+						if attr not in list(ldf.columns):
+							raise ValueError(f"The input attribute {attr} does not exist in the DataFrame.")
 				else:
-						check_attr_exists = clause.attribute in list(ldf.columns)
-						if clause.attribute and not check_attr_exists:
-							print_warning = True
-
+					if (clause.attribute and clause.attribute!="Record"):
+						if not clause.attribute in list(ldf.columns):
+							raise ValueError(f"The input attribute {clause.attribute} does not exist in the DataFrame.")
+					if (clause.value and clause.attribute and clause.filter_op=="="):
+						series = ldf[clause.attribute].values
 						if isinstance(clause.value, list):
-							check_val_exists = clause.attribute in unique_vals and all(v in unique_vals[clause.attribute] for v in clause.value)
+							vals = clause.value
 						else:
-							check_val_exists = clause.attribute in unique_vals and clause.value in unique_vals[clause.attribute]
-						if clause.value and not check_val_exists:
-							print_warning = True
-				
-				if isinstance(clause.value, list):
-					check_val_exists_group = all(exists_in_df(val, unique_vals) for val in clause.value)
-					if clause.value and not check_val_exists_group:
-						print_warning = True
+							vals = [clause.value]
+						for val in vals:
+							if (val not in series):#(not series.str.contains(val).any()):
+								raise ValueError(f"The input value {val} does not exist for the attribute {clause.attribute} for the DataFrame.")
 
-		# 1. Parse all string specification into Clause objects (nice-to-have)
-		# 2. Validate that the parsed specification is corresponds to the content in the LuxDataframe.
 		for clause in intent:
 			if type(clause) is list:
 				for s in clause:
-					validate_attr(s)
+					validate_clause(s)
 			else:
-				validate_attr(clause)
-
-		if print_warning:
-			raise ValueError("Input clause is inconsistent with DataFrame.")
-
-		# lux.set_intent(lux.Clause(attr = "Horsepower"))
-		# lux.set_intent(lux.Clause(attr = "A")) --> Warning
+				validate_clause(clause)

--- a/lux/compiler/Validator.py
+++ b/lux/compiler/Validator.py
@@ -2,7 +2,7 @@
 from lux.luxDataFrame.LuxDataframe import LuxDataFrame
 from lux.vis.Clause import Clause
 from typing import List
-from lux.utils.date_utils import check_is_datetime
+from lux.utils.date_utils import is_datetime_series,is_datetime_string
 
 class Validator:
 	'''
@@ -41,19 +41,21 @@ class Validator:
 						if attr not in list(ldf.columns):
 							raise ValueError(f"The input attribute {attr} does not exist in the DataFrame.")
 				else:
-					if (clause.attribute and clause.attribute!="Record"):
-						if not clause.attribute in list(ldf.columns):
-							raise ValueError(f"The input attribute {clause.attribute} does not exist in the DataFrame.")
-					if (clause.value and clause.attribute and clause.filter_op=="="):
-						series = ldf[clause.attribute]
-						if (not check_is_datetime(series)): #we don't value check datetime since datetime can take filter values that don't exactly match the exact TimeStamp representation
-							if isinstance(clause.value, list):
-								vals = clause.value
-							else:
-								vals = [clause.value]
-							for val in vals:
-								if (val not in series.values):#(not series.str.contains(val).any()):
-									raise ValueError(f"The input value {val} does not exist for the attribute {clause.attribute} for the DataFrame.")
+					if (clause.attribute!="Record"):
+						#we don't value check datetime since datetime can take filter values that don't exactly match the exact TimeStamp representation
+						if (clause.attribute and not is_datetime_string(clause.attribute)):
+							if not clause.attribute in list(ldf.columns):
+								raise ValueError(f"The input attribute {clause.attribute} does not exist in the DataFrame.")
+						if (clause.value and clause.attribute and clause.filter_op=="="):
+							series = ldf[clause.attribute]
+							if (not is_datetime_series(series)): 
+								if isinstance(clause.value, list):
+									vals = clause.value
+								else:
+									vals = [clause.value]
+								for val in vals:
+									if (val not in series.values):#(not series.str.contains(val).any()):
+										raise ValueError(f"The input value {val} does not exist for the attribute {clause.attribute} for the DataFrame.")
 
 		for clause in intent:
 			if type(clause) is list:

--- a/lux/compiler/Validator.py
+++ b/lux/compiler/Validator.py
@@ -2,6 +2,8 @@
 from lux.luxDataFrame.LuxDataframe import LuxDataFrame
 from lux.vis.Clause import Clause
 from typing import List
+from lux.utils.date_utils import check_is_datetime
+
 class Validator:
 	'''
 	Contains methods for validating lux.Clause objects in the intent.
@@ -43,14 +45,15 @@ class Validator:
 						if not clause.attribute in list(ldf.columns):
 							raise ValueError(f"The input attribute {clause.attribute} does not exist in the DataFrame.")
 					if (clause.value and clause.attribute and clause.filter_op=="="):
-						series = ldf[clause.attribute].values
-						if isinstance(clause.value, list):
-							vals = clause.value
-						else:
-							vals = [clause.value]
-						for val in vals:
-							if (val not in series):#(not series.str.contains(val).any()):
-								raise ValueError(f"The input value {val} does not exist for the attribute {clause.attribute} for the DataFrame.")
+						series = ldf[clause.attribute]
+						if (not check_is_datetime(series)): #we don't value check datetime since datetime can take filter values that don't exactly match the exact TimeStamp representation
+							if isinstance(clause.value, list):
+								vals = clause.value
+							else:
+								vals = [clause.value]
+							for val in vals:
+								if (val not in series.values):#(not series.str.contains(val).any()):
+									raise ValueError(f"The input value {val} does not exist for the attribute {clause.attribute} for the DataFrame.")
 
 		for clause in intent:
 			if type(clause) is list:

--- a/lux/data/stocks.csv
+++ b/lux/data/stocks.csv
@@ -1,4 +1,4 @@
-symbol,date,price
+symbol,monthdate,price
 MSFT,2000-01-01,39.81
 MSFT,2000-02-01,36.35
 MSFT,2000-03-01,43.22

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -187,11 +187,7 @@ class PandasExecutor(Executor):
                     for col in columns[2:]:
                         view.data[col] = view.data[col].fillna(0)
                     assert len(list(view.data[groupby_attr.attribute])) == len(all_attr_vals)*len(color_attr_vals), f"Aggregated data missing values compared to original range of values of `{groupby_attr.attribute, color_attr.attribute}`."
-                    # for vals in all_attr_vals:
-                    #     for cvals in color_attr_vals:
-                    #         temp_combi = [vals, cvals]
-                    #         if (temp_combi not in res_color_combi_vals):
-                    #             view.data.loc[len(view.data)] = [vals]+[cvals]+[0]*(len(view.data.columns)-2)
+                    view.data = view.data.iloc[:,:3] # Keep only the three relevant columns not the *_right columns resulting from merge
                 else:
                     df = pd.DataFrame({columns[0]: all_attr_vals})
                     
@@ -233,7 +229,7 @@ class PandasExecutor(Executor):
 
     @staticmethod
     def execute_filter(view: Vis):
-        assert view.data is not None, "execute_filter assumes input view.data is populated (if not, populate with LuxDataFrame values)"
+        assert view.data is not None, "execute_filter assumes input vis.data is populated (if not, populate with LuxDataFrame values)"
         filters = utils.get_filter_specs(view._inferred_intent)
         
         if (filters):

--- a/lux/luxDataFrame/LuxDataframe.py
+++ b/lux/luxDataFrame/LuxDataframe.py
@@ -3,7 +3,7 @@ from lux.vis.Clause import Clause
 from lux.vis.Vis import Vis
 from lux.vis.VisList import VisList
 from lux.utils.utils import check_import_lux_widget
-from lux.utils.date_utils import check_is_datetime
+from lux.utils.date_utils import is_datetime_series
 #import for benchmarking
 import time
 import typing
@@ -44,10 +44,8 @@ class LuxDataFrame(pd.DataFrame):
         self.cardinality = None
         self.min_max = None
         self.pre_aggregated = None
-        self._compiled=False
-        self._metadata_fresh=False
     def maintain_metadata(self):
-        if (not self._metadata_fresh): # Check that metadata has not yet been computed
+        if (not hasattr(self,"_metadata_fresh") or not self._metadata_fresh ): # Check that metadata has not yet been computed
             if (len(self)>0): #only compute metadata information if the dataframe is non-empty
                 self.compute_stats()
                 self.compute_dataset_metadata()
@@ -74,7 +72,6 @@ class LuxDataFrame(pd.DataFrame):
     #     self.expire_metadata()
 
     def _update_inplace(self,*args,**kwargs):
-        print ("update inplace")
         # super(LuxDataFrame, self)._update_inplace(*args,**kwargs)
         self.expire_metadata()
 
@@ -242,7 +239,7 @@ class LuxDataFrame(pd.DataFrame):
             # Eliminate this clause because a single NaN value can cause the dtype to be object
             elif self.dtypes[attr] == "object":
                 self.data_type_lookup[attr] = "nominal"
-            elif check_is_datetime(self.dtypes[attr]): #check if attribute is any type of datetime dtype
+            elif is_datetime_series(self.dtypes[attr]): #check if attribute is any type of datetime dtype
                 self.data_type_lookup[attr] = "temporal"
         # for attr in list(df.dtypes[df.dtypes=="int64"].keys()):
         # 	if self.cardinality[attr]>50:

--- a/lux/utils/date_utils.py
+++ b/lux/utils/date_utils.py
@@ -66,3 +66,4 @@ def compute_date_granularity(date_column:pd.core.series.Series):
 	for field in date_fields:
 		if hasattr(date_index,field) and len(getattr(date_index, field).unique()) != 1 : #can be changed to sum(getattr(date_index, field)) != 0
 			return field
+	return "year" #if none, then return year by default

--- a/lux/utils/date_utils.py
+++ b/lux/utils/date_utils.py
@@ -67,3 +67,5 @@ def compute_date_granularity(date_column:pd.core.series.Series):
 		if hasattr(date_index,field) and len(getattr(date_index, field).unique()) != 1 : #can be changed to sum(getattr(date_index, field)) != 0
 			return field
 	return "year" #if none, then return year by default
+def check_is_datetime(series):
+	return pd.api.types.is_datetime64_any_dtype(series) or pd.api.types.is_period_dtype(series)

--- a/lux/utils/date_utils.py
+++ b/lux/utils/date_utils.py
@@ -67,5 +67,36 @@ def compute_date_granularity(date_column:pd.core.series.Series):
 		if hasattr(date_index,field) and len(getattr(date_index, field).unique()) != 1 : #can be changed to sum(getattr(date_index, field)) != 0
 			return field
 	return "year" #if none, then return year by default
-def check_is_datetime(series):
+def is_datetime_series(series:pd.Series) -> bool:
+	
+	"""
+	Check if the Series object is of datetime type
+
+	Parameters
+	----------
+	series : pd.Series
+
+	Returns
+	-------
+	is_date: bool
+	"""	
 	return pd.api.types.is_datetime64_any_dtype(series) or pd.api.types.is_period_dtype(series)
+def is_datetime_string(string:str)-> bool:
+	"""
+	Check if the string is date-like.
+
+	Parameters
+	----------
+	string : str
+
+	Returns
+	-------
+	is_date: bool
+	"""	
+	from dateutil.parser import parse
+	try: 
+		parse(string)
+		return True
+
+	except ValueError:
+		return False

--- a/lux/vis/Vis.py
+++ b/lux/vis/Vis.py
@@ -82,7 +82,6 @@ class Vis:
 		from IPython.display import display
 		check_import_lux_widget()
 		import luxWidget
-		self.refresh_source(self._source)
 		if (self.data is None):
 			raise Exception("No data is populated in Vis. In order to generate data required for the vis, use the 'refresh_source' function to populate the Vis with a data source (e.g., vis.refresh_source(df)).")
 		else:
@@ -218,8 +217,8 @@ class Vis:
 			from lux.compiler.Validator import Validator
 			from lux.compiler.Compiler import Compiler
 			from lux.executor.PandasExecutor import PandasExecutor #TODO: temporary (generalize to executor)
+			ldf.maintain_metadata()
 			self._source = ldf
-			self._source.maintain_metadata()
 			#TODO: handle case when user input vanilla Pandas dataframe
 			self._inferred_intent = Parser.parse(self._intent)
 			Validator.validate_intent(self._inferred_intent,ldf)

--- a/lux/vis/VisList.py
+++ b/lux/vis/VisList.py
@@ -209,7 +209,6 @@ class VisList():
 		self._widget =  None
 		from IPython.display import display
 		from lux.luxDataFrame.LuxDataframe import LuxDataFrame
-		self.refresh_source(self._source)
 		recommendation = {"action": "Vis List",
 					  "description": "Shows a vis list defined by the intent"}
 		recommendation["collection"] = self._collection

--- a/lux/vis/VisList.py
+++ b/lux/vis/VisList.py
@@ -23,7 +23,7 @@ class VisList():
 			self._collection = []
 			self._intent = []
 		self._widget = None
-		if (source is not None): self.refresh_source(source)
+		self.refresh_source(self._source)
 	def set_intent(self, intent:List[Clause]) -> None:
 		"""
 		Sets the intent of the VisList and refresh the source based on the new clause
@@ -209,6 +209,7 @@ class VisList():
 		self._widget =  None
 		from IPython.display import display
 		from lux.luxDataFrame.LuxDataframe import LuxDataFrame
+		self.refresh_source(self._source)
 		recommendation = {"action": "Vis List",
 					  "description": "Shows a vis list defined by the intent"}
 		recommendation["collection"] = self._collection
@@ -246,19 +247,21 @@ class VisList():
 		----
 		Function derives a new _inferred_intent by instantiating the intent specification on the new data
 		"""		
-		from lux.compiler.Parser import Parser
-		from lux.compiler.Validator import Validator
-		from lux.compiler.Compiler import Compiler
-		from lux.executor.PandasExecutor import PandasExecutor #TODO: temporary (generalize to executor)
-		self._source = ldf
-		if len(self._input_lst)>0:
-			if (self._is_vis_input()):
-				for vis in self._collection:
-					vis._inferred_intent = Parser.parse(vis._intent)
-					Validator.validate_spec(vis._inferred_intent,ldf)
-				self._collection = Compiler.compile(ldf,ldf._intent,self,enumerate_collection=False)
-			else:
-				self._inferred_intent = Parser.parse(self._intent)
-				Validator.validate_spec(self._inferred_intent,ldf)
-				self._collection = Compiler.compile(ldf,self._inferred_intent,self)
-			ldf.executor.execute(self._collection,ldf)
+		if (ldf is not None):
+			from lux.compiler.Parser import Parser
+			from lux.compiler.Validator import Validator
+			from lux.compiler.Compiler import Compiler
+			from lux.executor.PandasExecutor import PandasExecutor #TODO: temporary (generalize to executor)
+			self._source = ldf
+			self._source.maintain_metadata()
+			if len(self._input_lst)>0:
+				if (self._is_vis_input()):
+					for vis in self._collection:
+						vis._inferred_intent = Parser.parse(vis._intent)
+						Validator.validate_intent(vis._inferred_intent,ldf)
+					self._collection = Compiler.compile(ldf,ldf._intent,self,enumerate_collection=False)
+				else:
+					self._inferred_intent = Parser.parse(self._intent)
+					Validator.validate_intent(self._inferred_intent,ldf)
+					self._collection = Compiler.compile(ldf,self._inferred_intent,self)
+				ldf.executor.execute(self._collection,ldf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ altair>=4.0.0
 jupyter
 notebook
 vega_datasets
-pandas>=0.25.3
+pandas>=1.1.0
 pytest==5.3.1
 pytest-cov==2.8.1
 scikit-learn==0.22

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -26,7 +26,7 @@ def test_generalize_action():
 	df = pd.read_csv("lux/data/car.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y') # change pandas dtype for the column "Year" to datetype
 	df.set_intent(["Acceleration", "MilesPerGal", "Cylinders", "Origin=USA"])
-	df.show_more()
+	df._repr_html_()
 	assert(len(df.recommendation['Generalize']) == 4)
 	v1 = df.recommendation['Generalize'][0]
 	v2 = df.recommendation['Generalize'][1]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,30 +1,32 @@
 from .context import lux
 import pytest
 import pandas as pd
-
-def test_underspecified_no_vis(test_show_more):
-	no_view_actions = ["Correlation", "Distribution", "Occurrence","Temporal"]
+from lux.vis.Vis import Vis
+from lux.vis.VisList import VisList
+def test_underspecified_no_vis(test_recs):
+	no_vis_actions = ["Correlation", "Distribution", "Occurrence","Temporal"]
 	df = pd.read_csv("lux/data/car.csv")
-	test_show_more(df, no_view_actions)
+	test_recs(df, no_vis_actions)
 	assert len(df.current_vis) == 0
 
 	# test only one filter context case.
 	df.set_intent([lux.Clause(attribute ="Origin", filter_op="=", value="USA")])
-	test_show_more(df, no_view_actions)
+	test_recs(df, no_vis_actions)
 	assert len(df.current_vis) == 0
 
-def test_underspecified_single_vis(test_show_more):
-	one_view_actions = ["Enhance", "Filter", "Generalize"]
+def test_underspecified_single_vis(test_recs):
+	one_vis_actions = ["Enhance", "Filter", "Generalize"]
 	df = pd.read_csv("lux/data/car.csv")
 	df.set_intent([lux.Clause(attribute ="MilesPerGal"), lux.Clause(attribute ="Weight")])
+	test_recs(df, one_vis_actions)
 	assert len(df.current_vis) == 1
 	assert df.current_vis[0].mark == "scatter"
 	for attr in df.current_vis[0]._inferred_intent: assert attr.data_model == "measure"
 	for attr in df.current_vis[0]._inferred_intent: assert attr.data_type == "quantitative"
-	test_show_more(df, one_view_actions)
+	
 
-# def test_underspecified_vis_collection(test_show_more):
-# 	multiple_view_actions = ["Current Views"]
+# def test_underspecified_vis_collection(test_recs):
+# 	multiple_vis_actions = ["Current viss"]
 
 # 	df = pd.read_csv("lux/data/car.csv")
 # 	df["Year"] = pd.to_datetime(df["Year"], format='%Y') # change pandas dtype for the column "Year" to datetype
@@ -34,86 +36,82 @@ def test_underspecified_single_vis(test_show_more):
 # 	assert df.current_vis[0].mark == "line"
 # 	for vc in df.current_vis:
 # 		assert (vc.get_attr_by_channel("x")[0].attribute == "Year")
-# 	test_show_more(df, multiple_view_actions)
+# 	test_recs(df, multiple_vis_actions)
 
 # 	df.set_intent([lux.Clause(attribute ="?"), lux.Clause(attribute ="Year", channel="x")])
 # 	assert len(df.current_vis) == len(list(df.columns)) - 1 # we remove year by year so its 8 vis instead of 9
 # 	for vc in df.current_vis:
 # 		assert (vc.get_attr_by_channel("x")[0].attribute == "Year")
-# 	test_show_more(df, multiple_view_actions)
+# 	test_recs(df, multiple_vis_actions)
 
 # 	df.set_intent([lux.Clause(attribute ="?", data_type="quantitative"), lux.Clause(attribute ="Year")])
-# 	assert len(df.current_vis) == len([view.get_attr_by_data_type("quantitative") for view in df.current_vis]) # should be 5
-# 	test_show_more(df, multiple_view_actions)
+# 	assert len(df.current_vis) == len([vis.get_attr_by_data_type("quantitative") for vis in df.current_vis]) # should be 5
+# 	test_recs(df, multiple_vis_actions)
 
 # 	df.set_intent([lux.Clause(attribute ="?", data_model="measure"), lux.Clause(attribute="MilesPerGal", channel="y")])
 # 	for vc in df.current_vis:
 # 		print (vc.get_attr_by_channel("y")[0].attribute == "MilesPerGal")
-# 	test_show_more(df, multiple_view_actions)
+# 	test_recs(df, multiple_vis_actions)
 
 # 	df.set_intent([lux.Clause(attribute ="?", data_model="measure"), lux.Clause(attribute ="?", data_model="measure")])
-# 	assert len(df.current_vis) == len([view.get_attr_by_data_model("measure") for view in df.current_vis]) #should be 25
-# 	test_show_more(df, multiple_view_actions)
+# 	assert len(df.current_vis) == len([vis.get_attr_by_data_model("measure") for vis in df.current_vis]) #should be 25
+# 	test_recs(df, multiple_vis_actions)
 
 @pytest.fixture
-def test_show_more():
-	def test_show_more_function(df, actions):
-		df.show_more()
+def test_recs():
+	def test_recs_function(df, actions):
+		df._repr_html_()
 		assert (len(df._rec_info) > 0)
 		for rec in df._rec_info:
 			assert (rec["action"] in actions)
-	return test_show_more_function
+	return test_recs_function
 
 def test_parse():
 	df = pd.read_csv("lux/data/car.csv")
-	df.set_intent([lux.Clause("Origin=?"), lux.Clause(attribute ="MilesPerGal")])
-	assert len(df.current_vis) == 3
+	vlst = VisList([lux.Clause("Origin=?"), lux.Clause(attribute ="MilesPerGal")],df)
+	assert len(vlst) == 3
 
 	df = pd.read_csv("lux/data/car.csv")
-	df.set_intent([lux.Clause("Origin=?"), lux.Clause("MilesPerGal")])
-	assert len(df.current_vis) == 3
+	vlst = VisList([lux.Clause("Origin=?"), lux.Clause("MilesPerGal")],df)
+	assert len(vlst) == 3
 def test_underspecified_vis_collection_zval():
 	# check if the number of charts is correct
 	df = pd.read_csv("lux/data/car.csv")
-	df.set_intent([lux.Clause(attribute ="Origin", filter_op="=", value="?"), lux.Clause(attribute ="MilesPerGal")])
-	assert len(df.current_vis) == 3
+	vlst = VisList([lux.Clause(attribute ="Origin", filter_op="=", value="?"), lux.Clause(attribute ="MilesPerGal")],df)
+	assert len(vlst) == 3
 
 	#does not work
 	# df = pd.read_csv("lux/data/cars.csv")
-	# df.set_intent([lux.Clause(attribute = ["Origin","Cylinders"], filter_op="=",value="?"),lux.Clause(attribute = ["Horsepower"]),lux.Clause(attribute = "Weight")])
-	# assert len(df.current_vis) == 8
+	# vlst = VisList([lux.Clause(attribute = ["Origin","Cylinders"], filter_op="=",value="?"),lux.Clause(attribute = ["Horsepower"]),lux.Clause(attribute = "Weight")],df)
+	# assert len(vlst) == 8
 
 def test_sort_bar():
 	from lux.compiler.Compiler import Compiler
 	from lux.vis.Vis import Vis
 	df = pd.read_csv("lux/data/car.csv")
-	view = Vis([lux.Clause(attribute="Acceleration",data_model="measure",data_type="quantitative"),
-				lux.Clause(attribute="Origin",data_model="dimension",data_type="nominal")])
-	Compiler.determine_encoding(df, view)
-	assert view.mark == "bar"
-	assert view._inferred_intent[1].sort == ''
+	vis = Vis([lux.Clause(attribute="Acceleration",data_model="measure",data_type="quantitative"),
+				lux.Clause(attribute="Origin",data_model="dimension",data_type="nominal")],df)
+	assert vis.mark == "bar"
+	assert vis._inferred_intent[1].sort == ''
 
 	df = pd.read_csv("lux/data/car.csv")
-	view = Vis([lux.Clause(attribute="Acceleration",data_model="measure",data_type="quantitative"),
-				lux.Clause(attribute="Name",data_model="dimension",data_type="nominal")])
-	Compiler.determine_encoding(df, view)
-	assert view.mark == "bar"
-	assert view._inferred_intent[1].sort == 'ascending'
+	vis = Vis([lux.Clause(attribute="Acceleration",data_model="measure",data_type="quantitative"),
+				lux.Clause(attribute="Name",data_model="dimension",data_type="nominal")],df)
+	assert vis.mark == "bar"
+	assert vis._inferred_intent[1].sort == 'ascending'
 
 def test_specified_vis_collection():
 	df = pd.read_csv("lux/data/cars.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y')  # change pandas dtype for the column "Year" to datetype
 
-	df.set_intent(
-		[lux.Clause(attribute="Horsepower"),lux.Clause(attribute="Brand"), lux.Clause(attribute = "Origin",value=["Japan","USA"])])
-	assert len(df.current_vis) == 2
+	vlst = VisList([lux.Clause(attribute="Horsepower"),lux.Clause(attribute="Brand"), lux.Clause(attribute = "Origin",value=["Japan","USA"])],df)
+	assert len(vlst) == 2
 
-	df.set_intent(
-		[lux.Clause(attribute=["Horsepower","Weight"]),lux.Clause(attribute="Brand"), lux.Clause(attribute = "Origin",value=["Japan","USA"])])
-	assert len(df.current_vis) == 4
+	vlst = VisList([lux.Clause(attribute=["Horsepower","Weight"]),lux.Clause(attribute="Brand"), lux.Clause(attribute = "Origin",value=["Japan","USA"])],df)
+	assert len(vlst) == 4
 
-# 	# test if z axis has been filtered correctly
-	chart_titles = [view.title for view in df.current_vis._collection]
+	# test if z axis has been filtered correctly
+	chart_titles = [vis.title for vis in vlst]
 	assert "Origin = USA" and "Origin = Japan" in chart_titles
 	assert "Origin = Europe" not in chart_titles
 
@@ -121,69 +119,59 @@ def test_specified_vis_collection():
 def test_specified_channel_enforced_vis_collection():
 	df = pd.read_csv("lux/data/cars.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y')  # change pandas dtype for the column "Year" to datetype
-	df.set_intent(
-		[lux.Clause(attribute="?"),lux.Clause(attribute="MilesPerGal",channel="x")])
-	for view in df.current_vis:
-		check_attribute_on_channel(view, "MilesPerGal", "x")
+	visList = VisList([lux.Clause(attribute="?"),lux.Clause(attribute="MilesPerGal",channel="x")],df)
+	for vis in visList:
+		check_attribute_on_channel(vis, "MilesPerGal", "x")
 
 def test_autoencoding_scatter():
 	# No channel specified
 	df = pd.read_csv("lux/data/cars.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y')  # change pandas dtype for the column "Year" to datetype
-	df.set_intent([lux.Clause(attribute="MilesPerGal"), lux.Clause(attribute="Weight")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "MilesPerGal", "x")
-	check_attribute_on_channel(view, "Weight", "y")
+	vis = Vis([lux.Clause(attribute="MilesPerGal"), lux.Clause(attribute="Weight")],df)
+	check_attribute_on_channel(vis, "MilesPerGal", "x")
+	check_attribute_on_channel(vis, "Weight", "y")
 
 	# Partial channel specified
-	df.set_intent([lux.Clause(attribute="MilesPerGal", channel="y"), lux.Clause(attribute="Weight")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "MilesPerGal", "y")
-	check_attribute_on_channel(view, "Weight", "x")
+	vis = Vis([lux.Clause(attribute="MilesPerGal", channel="y"), lux.Clause(attribute="Weight")],df)
+	check_attribute_on_channel(vis, "MilesPerGal", "y")
+	check_attribute_on_channel(vis, "Weight", "x")
 
 	# Full channel specified
-	df.set_intent([lux.Clause(attribute="MilesPerGal", channel="y"), lux.Clause(attribute="Weight", channel="x")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "MilesPerGal", "y")
-	check_attribute_on_channel(view, "Weight", "x")
+	vis = Vis([lux.Clause(attribute="MilesPerGal", channel="y"), lux.Clause(attribute="Weight", channel="x")],df)
+	check_attribute_on_channel(vis, "MilesPerGal", "y")
+	check_attribute_on_channel(vis, "Weight", "x")
 	# Duplicate channel specified
 	with pytest.raises(ValueError):
 		# Should throw error because there should not be columns with the same channel specified
 		df.set_intent([lux.Clause(attribute="MilesPerGal", channel="x"), lux.Clause(attribute="Weight", channel="x")])
-
 	
 def test_autoencoding_histogram():
 	# No channel specified
 	df = pd.read_csv("lux/data/cars.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y')  # change pandas dtype for the column "Year" to datetype
-	df.set_intent([lux.Clause(attribute="MilesPerGal", channel="y")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "MilesPerGal", "y")
+	vis = Vis([lux.Clause(attribute="MilesPerGal", channel="y")],df)
+	check_attribute_on_channel(vis, "MilesPerGal", "y")
 
-	# Record instead of count
-	# df.set_intent([lux.Clause(attribute="MilesPerGal",channel="x")])
-	# assert df.current_vis[0].get_attr_by_channel("x")[0].attribute == "MilesPerGal"
-	# assert df.current_vis[0].get_attr_by_channel("y")[0].attribute == "count()"
+	vis = Vis([lux.Clause(attribute="MilesPerGal",channel="x")],df)
+	assert vis.get_attr_by_channel("x")[0].attribute == "MilesPerGal"
+	assert vis.get_attr_by_channel("y")[0].attribute == "Record"
 
 def test_autoencoding_line_chart():
 	df = pd.read_csv("lux/data/cars.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y')  # change pandas dtype for the column "Year" to datetype
-	df.set_intent([lux.Clause(attribute="Year"), lux.Clause(attribute="Acceleration")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "Year", "x")
-	check_attribute_on_channel(view, "Acceleration", "y")
+	vis = Vis([lux.Clause(attribute="Year"), lux.Clause(attribute="Acceleration")],df)
+	check_attribute_on_channel(vis, "Year", "x")
+	check_attribute_on_channel(vis, "Acceleration", "y")
 
 	# Partial channel specified
-	df.set_intent([lux.Clause(attribute="Year", channel="y"), lux.Clause(attribute="Acceleration")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "Year", "y")
-	check_attribute_on_channel(view, "Acceleration", "x")
+	vis = Vis([lux.Clause(attribute="Year", channel="y"), lux.Clause(attribute="Acceleration")],df)
+	check_attribute_on_channel(vis, "Year", "y")
+	check_attribute_on_channel(vis, "Acceleration", "x")
 
 	# Full channel specified
-	df.set_intent([lux.Clause(attribute="Year", channel="y"), lux.Clause(attribute="Acceleration", channel="x")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "Year", "y")
-	check_attribute_on_channel(view, "Acceleration", "x")
+	vis = Vis([lux.Clause(attribute="Year", channel="y"), lux.Clause(attribute="Acceleration", channel="x")],df)
+	check_attribute_on_channel(vis, "Year", "y")
+	check_attribute_on_channel(vis, "Acceleration", "x")
 
 	with pytest.raises(ValueError):
 		# Should throw error because there should not be columns with the same channel specified
@@ -192,24 +180,20 @@ def test_autoencoding_line_chart():
 def test_autoencoding_color_line_chart():
 	df = pd.read_csv("lux/data/cars.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y')  # change pandas dtype for the column "Year" to datetype
-	df.set_intent([lux.Clause(attribute="Year"), lux.Clause(attribute="Acceleration"), lux.Clause(attribute="Origin")])
-
-	view = df.current_vis[0]
-
-	check_attribute_on_channel(view, "Year", "x")
-	check_attribute_on_channel(view, "Acceleration", "y")
-	check_attribute_on_channel(view, "Origin", "color")
+	intent = [lux.Clause(attribute="Year"), lux.Clause(attribute="Acceleration"), lux.Clause(attribute="Origin")]
+	vis = Vis(intent,df)
+	check_attribute_on_channel(vis, "Year", "x")
+	check_attribute_on_channel(vis, "Acceleration", "y")
+	check_attribute_on_channel(vis, "Origin", "color")
 
 def test_autoencoding_color_scatter_chart():
 	df = pd.read_csv("lux/data/cars.csv")
 	df["Year"] = pd.to_datetime(df["Year"], format='%Y')  # change pandas dtype for the column "Year" to datetype
-	df.set_intent([lux.Clause(attribute="Horsepower"), lux.Clause(attribute="Acceleration"), lux.Clause(attribute="Origin")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "Origin", "color")
+	vis = Vis([lux.Clause(attribute="Horsepower"), lux.Clause(attribute="Acceleration"), lux.Clause(attribute="Origin")],df)
+	check_attribute_on_channel(vis, "Origin", "color")
 
-	df.set_intent([lux.Clause(attribute="Horsepower"), lux.Clause(attribute="Acceleration", channel="color"), lux.Clause(attribute="Origin")])
-	view = df.current_vis[0]
-	check_attribute_on_channel(view, "Acceleration", "color")
+	vis = Vis([lux.Clause(attribute="Horsepower"), lux.Clause(attribute="Acceleration", channel="color"), lux.Clause(attribute="Origin")],df)
+	check_attribute_on_channel(vis, "Acceleration", "color")
 
 def test_populate_options():
 	from lux.compiler.Compiler import Compiler
@@ -222,6 +206,7 @@ def test_populate_options():
 	assert list_equal(list(col_set), list(df.columns))
 
 	df.set_intent([lux.Clause(attribute="?", data_model="measure"), lux.Clause(attribute="MilesPerGal")])
+	df._repr_html_()
 	col_set = set()
 	for specOptions in Compiler.populate_wildcard_options(df._intent, df)["attributes"]:
 		for clause in specOptions:
@@ -233,5 +218,5 @@ def list_equal(l1, l2):
     l2.sort()
     return l1==l2
 
-def check_attribute_on_channel(view, attr_name, channelName):
-	assert view.get_attr_by_channel(channelName)[0].attribute == attr_name
+def check_attribute_on_channel(vis, attr_name, channelName):
+	assert vis.get_attr_by_channel(channelName)[0].attribute == attr_name

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -43,7 +43,7 @@ def test_period_filter():
 	ldf.set_intent([lux.Clause(attribute ="Acceleration"), lux.Clause(attribute ="Horsepower")])
 
 	PandasExecutor.execute(ldf.current_vis, ldf)
-	ldf.show_more()
+	ldf._repr_html_()
 
 	assert isinstance(ldf.recommendation['Filter'][2]._inferred_intent[2].value, pd.Period)
 
@@ -57,7 +57,7 @@ def test_period_to_altair():
 	df.set_intent([lux.Clause(attribute ="Acceleration"), lux.Clause(attribute ="Horsepower")])
 
 	PandasExecutor.execute(df.current_vis, df)
-	df.show_more()
+	df._repr_html_()
 
 	exported_code = df.recommendation['Filter'][2].to_Altair()
 	
@@ -65,7 +65,7 @@ def test_period_to_altair():
 
 def test_refresh_inplace():
 	df = pd.DataFrame({'date': ['2020-01-01', '2020-02-01', '2020-03-01', '2020-04-01'], 'value': [10.5,15.2,20.3,25.2]})
-	
+	df._repr_html_()
 	assert df.data_type['nominal'][0] == 'date'
 
 	from lux.vis.Vis import Vis

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -66,7 +66,7 @@ def test_period_to_altair():
 def test_refresh_inplace():
 	df = pd.DataFrame({'date': ['2020-01-01', '2020-02-01', '2020-03-01', '2020-04-01'], 'value': [10.5,15.2,20.3,25.2]})
 	df._repr_html_()
-	assert df.data_type['nominal'][0] == 'date'
+	assert df.data_type_lookup["date"]=="temporal"
 
 	from lux.vis.Vis import Vis
 	vis = Vis(["date","value"],df)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -12,11 +12,11 @@ def test_display_LuxDataframe():
     
 def test_display_ViewCollection():
     df = pd.read_csv("lux/data/car.csv")
-    df.show_more()
+    df._repr_html_()
     df.recommendation["Correlation"]._repr_html_()
     
 def test_display_View():
     df = pd.read_csv("lux/data/car.csv")
-    df.show_more()
+    df._repr_html_()
     df.recommendation["Correlation"][0]._repr_html_()
     

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,39 +2,40 @@ from .context import lux
 import pytest
 import pandas as pd
 from lux.executor.PandasExecutor import PandasExecutor
+from lux.vis.Vis import Vis
+from lux.vis.VisList import VisList
 def test_lazy_execution():
     df = pd.read_csv("lux/data/car.csv")
-    df.set_intent([lux.Clause(attribute ="Horsepower", aggregation="mean"), lux.Clause(attribute ="Origin")])
+    intent = [lux.Clause(attribute ="Horsepower", aggregation="mean"), lux.Clause(attribute ="Origin")]
+    vis = Vis(intent)
     # Check data field in vis is empty before calling executor
-    assert df.current_vis[0].data == None
-    PandasExecutor.execute(df.current_vis, df)
-    assert type(df.current_vis[0].data) == lux.luxDataFrame.LuxDataframe.LuxDataFrame
+    assert vis.data is None
+    PandasExecutor.execute([vis], df)
+    assert type(vis.data) == lux.luxDataFrame.LuxDataframe.LuxDataFrame
     
 def test_selection():
     df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y') # change pandas dtype for the column "Year" to datetype
-    df.set_intent([lux.Clause(attribute = ["Horsepower", "Weight", "Acceleration"]), lux.Clause(attribute ="Year")])
-
-    PandasExecutor.execute(df.current_vis, df)
-
-    assert all([type(vc.data) == lux.luxDataFrame.LuxDataframe.LuxDataFrame for vc in df.current_vis])
-    assert all(df.current_vis[2].data.columns == ["Year", 'Acceleration'])
+    intent = [lux.Clause(attribute = ["Horsepower", "Weight", "Acceleration"]), lux.Clause(attribute ="Year")]
+    vislist = VisList(intent,df)
+    assert all([type(vis.data) == lux.luxDataFrame.LuxDataframe.LuxDataFrame for vis in vislist])
+    assert all(vislist[2].data.columns == ["Year", 'Acceleration'])
 
 def test_aggregation():
     df = pd.read_csv("lux/data/car.csv")
-    df.set_intent([lux.Clause(attribute ="Horsepower", aggregation="mean"), lux.Clause(attribute ="Origin")])
-    PandasExecutor.execute(df.current_vis, df)
-    result_df = df.current_vis[0].data
+    intent = [lux.Clause(attribute ="Horsepower", aggregation="mean"), lux.Clause(attribute ="Origin")]
+    vis = Vis(intent,df)
+    result_df = vis.data
     assert int(result_df[result_df["Origin"]=="USA"]["Horsepower"])==119
 
-    df.set_intent([lux.Clause(attribute ="Horsepower", aggregation="sum"), lux.Clause(attribute ="Origin")])
-    PandasExecutor.execute(df.current_vis, df)
-    result_df = df.current_vis[0].data
+    intent = [lux.Clause(attribute ="Horsepower", aggregation="sum"), lux.Clause(attribute ="Origin")]
+    vis = Vis(intent,df)
+    result_df = vis.data
     assert int(result_df[result_df["Origin"]=="Japan"]["Horsepower"])==6307
 
-    df.set_intent([lux.Clause(attribute ="Horsepower", aggregation="max"), lux.Clause(attribute ="Origin")])
-    PandasExecutor.execute(df.current_vis, df)
-    result_df = df.current_vis[0].data
+    intent = [lux.Clause(attribute ="Horsepower", aggregation="max"), lux.Clause(attribute ="Origin")]
+    vis = Vis(intent,df)
+    result_df = vis.data
     assert int(result_df[result_df["Origin"]=="Europe"]["Horsepower"])==133
 
 def test_colored_bar_chart():
@@ -46,8 +47,7 @@ def test_colored_bar_chart():
     y_clause = Clause(attribute = "Origin", channel = "y")
     color_clause = Clause(attribute = 'Cylinders', channel = "color")
 
-    new_vis = Vis([x_clause, y_clause, color_clause])
-    new_vis.refresh_source(df)
+    new_vis = Vis([x_clause, y_clause, color_clause],df)
     #make sure dimention of the data is correct
     color_cardinality = len(df.unique_values['Cylinders'])
     group_by_cardinality = len(df.unique_values['Origin'])
@@ -64,8 +64,7 @@ def test_colored_line_chart():
     y_clause = Clause(attribute = "MilesPerGal", channel = "y")
     color_clause = Clause(attribute = 'Cylinders', channel = "color")
 
-    new_vis = Vis([x_clause, y_clause, color_clause])
-    new_vis.refresh_source(df)
+    new_vis = Vis([x_clause, y_clause, color_clause],df)
     #make sure dimention of the data is correct
     color_cardinality = len(df.unique_values['Cylinders'])
     group_by_cardinality = len(df.unique_values['Year'])
@@ -75,49 +74,46 @@ def test_colored_line_chart():
 def test_filter():
     df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y') # change pandas dtype for the column "Year" to datetype
-    df.set_intent([lux.Clause(attribute ="Horsepower"), lux.Clause(attribute ="Year"), lux.Clause(attribute ="Origin", filter_op="=", value ="USA")])
-    vis = df.current_vis[0]
+    intent = [lux.Clause(attribute ="Horsepower"), lux.Clause(attribute ="Year"), lux.Clause(attribute ="Origin", filter_op="=", value ="USA")]
+    vis = Vis(intent,df)
     vis.data = df
     PandasExecutor.execute_filter(vis)
     assert len(vis.data) == len(df[df["Origin"]=="USA"])
 def test_inequalityfilter():
     df = pd.read_csv("lux/data/car.csv")
-    df.set_intent([lux.Clause(attribute ="Horsepower", filter_op=">", value=50), lux.Clause(attribute ="MilesPerGal")])
-    vis = df.current_vis[0]
+    vis = Vis([lux.Clause(attribute ="Horsepower", filter_op=">", value=50), lux.Clause(attribute ="MilesPerGal")])
     vis.data = df
     PandasExecutor.execute_filter(vis)
     assert len(df) > len(vis.data)
     assert len(vis.data) == 386 
     
-    df.set_intent([lux.Clause(attribute ="Horsepower", filter_op="<=", value=100), lux.Clause(attribute ="MilesPerGal")])
-    vis = df.current_vis[0]
+    intent = [lux.Clause(attribute ="Horsepower", filter_op="<=", value=100), lux.Clause(attribute ="MilesPerGal")]
+    vis = Vis(intent,df)
     vis.data = df
     PandasExecutor.execute_filter(vis)
     assert len(vis.data) == len(df[df["Horsepower"]<=100]) == 242
 
     # Test end-to-end
-    PandasExecutor.execute(df.current_vis, df)
-    Nbins =list(filter(lambda x: x.bin_size!=0, df.current_vis[0]._inferred_intent))[0].bin_size
-    assert len(df.current_vis[0].data) == Nbins
+    PandasExecutor.execute([vis], df)
+    Nbins =list(filter(lambda x: x.bin_size!=0, vis._inferred_intent))[0].bin_size
+    assert len(vis.data) == Nbins
     
 def test_binning():
     df = pd.read_csv("lux/data/car.csv")
-    df.set_intent([lux.Clause(attribute ="Horsepower")])
-    PandasExecutor.execute(df.current_vis, df)
-    nbins =list(filter(lambda x: x.bin_size!=0, df.current_vis[0]._inferred_intent))[0].bin_size
-    assert len(df.current_vis[0].data) == nbins
+    vis = Vis([lux.Clause(attribute ="Horsepower")],df)
+    nbins =list(filter(lambda x: x.bin_size!=0, vis._inferred_intent))[0].bin_size
+    assert len(vis.data) == nbins
 
 def test_record():
     df = pd.read_csv("lux/data/car.csv")
-    df.set_intent([lux.Clause(attribute ="Cylinders")])
-    PandasExecutor.execute(df.current_vis, df)
-    assert len(df.current_vis[0].data) == len(df["Cylinders"].unique())
+    vis = Vis([lux.Clause(attribute ="Cylinders")],df)
+    assert len(vis.data) == len(df["Cylinders"].unique())
     
 def test_filter_aggregation_fillzero_aligned():
     df = pd.read_csv("lux/data/car.csv")
-    df.set_intent([lux.Clause(attribute="Cylinders"), lux.Clause(attribute="MilesPerGal"), lux.Clause("Origin=Japan")])
-    PandasExecutor.execute(df.current_vis, df)
-    result = df.current_vis[0].data
+    intent = [lux.Clause(attribute="Cylinders"), lux.Clause(attribute="MilesPerGal"), lux.Clause("Origin=Japan")]
+    vis = Vis(intent,df)
+    result = vis.data
     externalValidation = df[df["Origin"]=="Japan"].groupby("Cylinders").mean()["MilesPerGal"]
     assert result[result["Cylinders"]==5]["MilesPerGal"].values[0]==0
     assert result[result["Cylinders"]==8]["MilesPerGal"].values[0]==0
@@ -127,12 +123,10 @@ def test_filter_aggregation_fillzero_aligned():
 
 def test_exclude_attribute():
     df = pd.read_csv("lux/data/car.csv")
-    df.set_intent([lux.Clause("?", exclude=["Name", "Year"]), lux.Clause("Horsepower")])
-    vis = df.current_vis[0]
-    vis.data = df
-    PandasExecutor.execute_filter(vis)
-    for vc in df.current_vis:
-        assert (vc.get_attr_by_channel("x")[0].attribute != "Year")
-        assert (vc.get_attr_by_channel("x")[0].attribute != "Name")
-        assert (vc.get_attr_by_channel("y")[0].attribute != "Year")
-        assert (vc.get_attr_by_channel("y")[0].attribute != "Year") 
+    intent = [lux.Clause("?", exclude=["Name", "Year"]), lux.Clause("Horsepower")]
+    vislist = VisList(intent,df)
+    for vis in vislist:
+        assert (vis.get_attr_by_channel("x")[0].attribute != "Year")
+        assert (vis.get_attr_by_channel("x")[0].attribute != "Name")
+        assert (vis.get_attr_by_channel("y")[0].attribute != "Year")
+        assert (vis.get_attr_by_channel("y")[0].attribute != "Year") 

--- a/tests/test_interestingness.py
+++ b/tests/test_interestingness.py
@@ -10,7 +10,7 @@ def test_interestingness_1_0_0():
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     
     df.set_intent([lux.Clause(attribute = "Origin")])
-    df.show_more()
+    df._repr_html_()
     #check that top recommended enhance graph score is not none and that ordering makes intuitive sense
     assert interestingness(df.recommendation['Enhance'][0],df) != None
     rank1 = -1
@@ -52,7 +52,7 @@ def test_interestingness_0_1_0():
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
 
     df.set_intent([lux.Clause(attribute = "Horsepower")])
-    df.show_more()
+    df._repr_html_()
     #check that top recommended enhance graph score is not none and that ordering makes intuitive sense
     assert interestingness(df.recommendation['Enhance'][0],df) != None
     rank1 = -1
@@ -87,7 +87,7 @@ def test_interestingness_0_1_1():
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     
     df.set_intent([lux.Clause(attribute = "Origin", filter_op="=",value="?"),lux.Clause(attribute = "MilesPerGal")])
-    df.show_more()
+    df._repr_html_()
     assert interestingness(df.recommendation['Current Vis'][0],df) != None
     assert str(df.recommendation['Current Vis'][0]._inferred_intent[2].value) == 'USA'
 
@@ -96,7 +96,7 @@ def test_interestingness_1_1_0():
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
 
     df.set_intent([lux.Clause(attribute = "Horsepower"),lux.Clause(attribute = "Year")])
-    df.show_more()
+    df._repr_html_()
     #check that top recommended Enhance graph score is not none (all graphs here have same score)
     assert interestingness(df.recommendation['Enhance'][0],df) != None
 
@@ -122,7 +122,7 @@ def test_interestingness_1_1_1():
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
 
     df.set_intent([lux.Clause(attribute = "Horsepower"), lux.Clause(attribute = "Origin", filter_op="=",value = "USA", bin_size=20)])
-    df.show_more()
+    df._repr_html_()
     #check that top recommended Enhance graph score is not none and that ordering makes intuitive sense
     assert interestingness(df.recommendation['Enhance'][0],df) != None
     rank1 = -1
@@ -145,7 +145,7 @@ def test_interestingness_0_2_0():
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
 
     df.set_intent([lux.Clause(attribute = "Horsepower"),lux.Clause(attribute = "Acceleration")])
-    df.show_more()
+    df._repr_html_()
     #check that top recommended enhance graph score is not none and that ordering makes intuitive sense
     assert interestingness(df.recommendation['Enhance'][0],df) != None
     rank1 = -1
@@ -183,6 +183,6 @@ def test_interestingness_0_2_1():
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
 
     df.set_intent([lux.Clause(attribute = "Horsepower"),lux.Clause(attribute = "Acceleration"),lux.Clause(attribute = "Acceleration", filter_op=">",value = 10)])
-    df.show_more()
+    df._repr_html_()
     #check that top recommended Generalize graph score is not none
     assert interestingness(df.recommendation['Generalize'][0],df) != None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -52,6 +52,7 @@ def test_case5():
 def test_case6():
 	ldf = pd.read_csv("lux/data/car.csv")
 	ldf.set_intent(["Horsepower", "Origin=?"])
+	ldf._repr_html_()
 	assert(type(ldf._intent[0]) is lux.Clause)
 	assert(ldf._intent[0].attribute == "Horsepower")
 	assert(type(ldf._intent[1]) is lux.Clause)

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -41,7 +41,7 @@ def test_custom_plot_setting():
         return chart
     df = pd.read_csv("lux/data/car.csv")
     df.set_plot_config(change_color_make_transparent_add_title)
-    df.show_more()
+    df._repr_html_()
     config_mark_addition = 'chart = chart.configure_mark(color="green",opacity=0.2)'
     title_addition ='chart.title = "Test Title"'
     exported_code_str = df.recommendation["Correlation"][0].to_Altair()
@@ -68,8 +68,9 @@ def test_remove_identity():
     assert (vis._inferred_intent[0].attribute=="Horsepower"),"Remove only 1 instances of Horsepower"
 def test_refresh_collection():
     df = pd.read_csv("lux/data/car.csv")
+    df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
     df.set_intent([lux.Clause(attribute = "Acceleration"),lux.Clause(attribute = "Horsepower")])
-    df.show_more()
+    df._repr_html_()
     enhanceCollection = df.recommendation["Enhance"]
     enhanceCollection.refresh_source(df[df["Origin"]=="USA"])
 


### PR DESCRIPTION
Refactored LuxDataFrame implementation to avoid metadata computation in `__init__` since internal Pandas calls were causing unnecessary computation and slowdown. Metadata is no longer computed at dataframe creation and only computed at display time (and memorized). Metadata is invalidated when there is an in-place Pandas operation. Some preliminary performance results are shown here:
<img src="https://user-images.githubusercontent.com/5554675/90232844-d07f2e80-de4f-11ea-8fc9-dea4f23450b3.png" width=600></img>
