### PR TITLE
Fix bugs relating to dtype and metadata propagation

### DIFF
--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -564,7 +564,6 @@ class LuxDataFrame(pd.DataFrame):
 		except(KeyboardInterrupt,SystemExit):
 			raise
 		except:
-			raise
 			warnings.warn(
 					"\nUnexpected error in rendering Lux widget and recommendations. "
 					"Falling back to Pandas display.\n\n" 

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -52,10 +52,6 @@ class LuxDataFrame(pd.DataFrame):
 	@property
 	def _constructor(self):
 		return LuxDataFrame
-	def __setitem__(self,key,value):
-		super(LuxDataFrame, self).__setitem__(key, value)
-		self.expire_metadata()
-		self.expire_recs()
 	# @property
 	# def _constructor_sliced(self):
 	# 	def f(*args, **kwargs):
@@ -97,7 +93,14 @@ class LuxDataFrame(pd.DataFrame):
 	#     print ("lux finalize")
 	#     super(LuxDataFrame, self).__finalize__(other,method,**kwargs)
 	#     self.expire_metadata()
-
+	def __getattr__(self, name):
+		super(LuxDataFrame, self).__getattr__(name)
+		self.expire_metadata()
+		self.expire_recs()
+	def _set_axis(self, axis, labels):
+		super(LuxDataFrame, self)._set_axis(axis, labels)
+		self.expire_metadata()
+		self.expire_recs()
 	def _update_inplace(self,*args,**kwargs):
 		super(LuxDataFrame, self)._update_inplace(*args,**kwargs)
 		self.expire_metadata()
@@ -561,6 +564,7 @@ class LuxDataFrame(pd.DataFrame):
 		except(KeyboardInterrupt,SystemExit):
 			raise
 		except:
+			raise
 			warnings.warn(
 					"\nUnexpected error in rendering Lux widget and recommendations. "
 					"Falling back to Pandas display.\n\n" 

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import numpy as np
 from lux.vis.VisList import VisList
 from lux.vis.Vis import Vis
 from lux.core.frame import LuxDataFrame

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -1,10 +1,12 @@
 import pandas as pd
+import numpy as np
 from lux.vis.VisList import VisList
 from lux.vis.Vis import Vis
 from lux.core.frame import LuxDataFrame
 from lux.executor.Executor import Executor
 from lux.utils import utils
 from lux.utils.utils import check_import_lux_widget, check_if_id_like
+from lux.utils.date_utils import is_datetime_series
 import warnings
 
 
@@ -248,7 +250,7 @@ class PandasExecutor(Executor):
                 ldf.data_type_lookup[attr] = "temporal"
             elif ldf.dtypes[attr] == "float64":
                 ldf.data_type_lookup[attr] = "quantitative"
-            elif ldf.dtypes[attr] == "int64":
+            elif pd.api.types.is_integer_dtype(ldf.dtypes[attr]): 
                 # See if integer value is quantitative or nominal by checking if the ratio of cardinality/data size is less than 0.4 and if there are less than 10 unique values
                 if (ldf.pre_aggregated):
                     if (ldf.cardinality[attr]==len(ldf)):

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -74,7 +74,7 @@ def test_crosstab():
 	'Result':['Pass','Pass','Fail','Pass','Fail','Pass','Pass','Fail','Fail','Pass','Pass','Fail']}
 	
 	df = pd.DataFrame(d,columns=['Name','Exam','Subject','Result'])
-	result = pd.crosstab([df.Exam],df.Result)
+	result = pd.crosstab([df["Exam"]],df["Result"])
 	result._repr_html_()
 	assert list(result.recommendation.keys() ) == ['Row Groups','Column Groups']
 

--- a/tests/test_pandas_coverage.py
+++ b/tests/test_pandas_coverage.py
@@ -15,51 +15,53 @@ def test_deepcopy():
     saved_df._repr_html_();
     check_metadata_equal(df, saved_df)
 
-# def test_rename():
-#     for i in range(2):
-#         url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-#         df = pd.read_csv(url)
-#         df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
-#         df._repr_html_();
-#         if i == 0:
-#             new_df = df.copy(deep=True)
-#             df.rename(columns={"Name": "Car Name"}, inplace = True)
-#             df._repr_html_();
-#             new_df, df = df, new_df
-#         else:
-#             new_df = df.rename(columns={"Name": "Car Name"}, inplace = False)
-#         new_df._repr_html_();
-#         assert df.data_type_lookup != new_df.data_type_lookup
+def test_rename():
+    for i in range(2):
+        url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
+        df = pd.read_csv(url)
+        df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
+        df._repr_html_();
+        if i == 0:
+            new_df = df.copy(deep=True)
+            df.rename(columns={"Name": "Car Name"}, inplace = True)
+            df._repr_html_();
+            new_df, df = df, new_df
+            df._repr_html_()
+        else:
+            new_df = df.rename(columns={"Name": "Car Name"}, inplace = False)
+        new_df._repr_html_();
+        assert df.data_type_lookup != new_df.data_type_lookup
 
-#         assert df.data_type_lookup["Name"] == new_df.data_type_lookup["Car Name"]
+        assert df.data_type_lookup["Name"] == new_df.data_type_lookup["Car Name"]
 
-#         assert df.data_type != new_df.data_type
+        assert df.data_type != new_df.data_type
 
-#         assert df.data_type["nominal"][0] == "Name"
-#         assert new_df.data_type["nominal"][0] == "Car Name"
+        assert df.data_type["nominal"][0] == "Name"
+        assert new_df.data_type["nominal"][0] == "Car Name"
 
-#         assert df.data_model_lookup != new_df.data_model_lookup
+        assert df.data_model_lookup != new_df.data_model_lookup
 
-#         assert df.data_model_lookup["Name"] == new_df.data_model_lookup["Car Name"]
+        assert df.data_model_lookup["Name"] == new_df.data_model_lookup["Car Name"]
 
-#         assert df.data_model != new_df.data_model
+        assert df.data_model != new_df.data_model
 
-#         assert df.data_model["dimension"][0] == "Name"
-#         assert new_df.data_model["dimension"][0] == "Car Name"
+        assert df.data_model["dimension"][0] == "Name"
+        assert new_df.data_model["dimension"][0] == "Car Name"
 
-#         assert list(df.unique_values.values()) == list(new_df.unique_values.values())
-#         assert list(df.cardinality.values()) == list(new_df.cardinality.values())
-#         assert df._min_max == new_df._min_max
-#         assert df.pre_aggregated == new_df.pre_aggregated
-# def test_rename2():
+        assert list(df.unique_values.values()) == list(new_df.unique_values.values())
+        assert list(df.cardinality.values()) == list(new_df.cardinality.values())
+        assert df._min_max == new_df._min_max
+        assert df.pre_aggregated == new_df.pre_aggregated
+def test_rename2():
 
-#     url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-#     df = pd.read_csv(url)
-#     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
-#     df.columns = ["col1", "col2", "col3", "col4","col5", "col6", "col7", "col8", "col9", "col10"]
-#     assert list(df.recommendation.keys() ) == ['Correlation', 'Distribution', 'Occurrence', 'Temporal'] 
-#     assert len(df.cardinality) == 10
-#     assert "col2" in list(df.cardinality.keys())
+    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
+    df = pd.read_csv(url)
+    df["Year"] = pd.to_datetime(df["Year"], format='%Y')
+    df.columns = ["col1", "col2", "col3", "col4","col5", "col6", "col7", "col8", "col9", "col10"]
+    df._repr_html_()
+    assert list(df.recommendation.keys() ) == ['Correlation', 'Distribution', 'Occurrence', 'Temporal'] 
+    assert len(df.cardinality) == 10
+    assert "col2" in list(df.cardinality.keys())
 
 def test_concat():
 
@@ -155,23 +157,23 @@ def test_named_agg():
     assert list(new_df.recommendation.keys() ) == ['Column Groups']
     assert len(new_df.cardinality) == 4
 
-# def test_change_dtype():
-#     url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-#     df = pd.read_csv(url)
-#     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
-#     df["Cylinders"] = pd.Series(df["Cylinders"], dtype = "Int64")
-#     df._repr_html_()
-#     assert list(df.recommendation.keys() ) == ['Column Groups'] # TODO once bug is fixed
-#     assert len(df.cardinality) == 4 # TODO once bug is fixed
+def test_change_dtype():
+    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
+    df = pd.read_csv(url)
+    df["Year"] = pd.to_datetime(df["Year"], format='%Y')
+    df["Cylinders"] = pd.Series(df["Cylinders"], dtype = "Int64")
+    df._repr_html_()
+    assert list(df.recommendation.keys() ) == ['Correlation', 'Distribution', 'Occurrence', 'Temporal']
+    assert len(df.data_type_lookup) == 10
 
-# def test_get_dummies():
-#     url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-#     df = pd.read_csv(url)
-#     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
-#     new_df = pd.get_dummies(df)
-#     new_df._repr_html_()
-#     assert list(new_df.recommendation.keys() ) == ['Column Groups'] # TODO once bug is fixed
-#     assert len(new_df.cardinality) == 4 # TODO once bug is fixed
+def test_get_dummies():
+    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
+    df = pd.read_csv(url)
+    df["Year"] = pd.to_datetime(df["Year"], format='%Y')
+    new_df = pd.get_dummies(df)
+    new_df._repr_html_()
+    assert list(new_df.recommendation.keys() ) == ['Correlation', 'Distribution', 'Occurrence', 'Temporal']
+    assert len(new_df.data_type_lookup) == 339
 
 def test_drop():
     url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'

--- a/tests/test_pandas_coverage.py
+++ b/tests/test_pandas_coverage.py
@@ -15,44 +15,69 @@ def test_deepcopy():
     saved_df._repr_html_();
     check_metadata_equal(df, saved_df)
 
+def test_rename_inplace():
+    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
+    df = pd.read_csv(url)
+    df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
+    df._repr_html_();
+    new_df = df.copy(deep=True)
+    df.rename(columns={"Name": "Car Name"}, inplace = True)
+    df._repr_html_();
+    new_df._repr_html_();
+    new_df, df = df, new_df # new_df is the old dataframe (df) with the new column name changed inplace
+    
+    assert df.data_type_lookup != new_df.data_type_lookup
+
+    assert df.data_type_lookup["Name"] == new_df.data_type_lookup["Car Name"]
+
+    assert df.data_type != new_df.data_type
+
+    assert df.data_type["nominal"][0] == "Name"
+    assert new_df.data_type["nominal"][0] == "Car Name"
+
+    assert df.data_model_lookup != new_df.data_model_lookup
+
+    assert df.data_model_lookup["Name"] == new_df.data_model_lookup["Car Name"]
+
+    assert df.data_model != new_df.data_model
+
+    assert df.data_model["dimension"][0] == "Name"
+    assert new_df.data_model["dimension"][0] == "Car Name"
+
+    assert list(df.unique_values.values()) == list(new_df.unique_values.values())
+    assert list(df.cardinality.values()) == list(new_df.cardinality.values())
+    assert df._min_max == new_df._min_max
+    assert df.pre_aggregated == new_df.pre_aggregated
 def test_rename():
-    for i in range(2):
-        url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-        df = pd.read_csv(url)
-        df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
-        df._repr_html_();
-        if i == 0:
-            new_df = df.copy(deep=True)
-            df.rename(columns={"Name": "Car Name"}, inplace = True)
-            df._repr_html_();
-            new_df, df = df, new_df
-            df._repr_html_()
-        else:
-            new_df = df.rename(columns={"Name": "Car Name"}, inplace = False)
-        new_df._repr_html_();
-        assert df.data_type_lookup != new_df.data_type_lookup
+    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
+    df = pd.read_csv(url)
+    df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
+    df._repr_html_();
+    new_df = df.rename(columns={"Name": "Car Name"}, inplace = False)
+    new_df._repr_html_();
+    assert df.data_type_lookup != new_df.data_type_lookup
 
-        assert df.data_type_lookup["Name"] == new_df.data_type_lookup["Car Name"]
+    assert df.data_type_lookup["Name"] == new_df.data_type_lookup["Car Name"]
 
-        assert df.data_type != new_df.data_type
+    assert df.data_type != new_df.data_type
 
-        assert df.data_type["nominal"][0] == "Name"
-        assert new_df.data_type["nominal"][0] == "Car Name"
+    assert df.data_type["nominal"][0] == "Name"
+    assert new_df.data_type["nominal"][0] == "Car Name"
 
-        assert df.data_model_lookup != new_df.data_model_lookup
+    assert df.data_model_lookup != new_df.data_model_lookup
 
-        assert df.data_model_lookup["Name"] == new_df.data_model_lookup["Car Name"]
+    assert df.data_model_lookup["Name"] == new_df.data_model_lookup["Car Name"]
 
-        assert df.data_model != new_df.data_model
+    assert df.data_model != new_df.data_model
 
-        assert df.data_model["dimension"][0] == "Name"
-        assert new_df.data_model["dimension"][0] == "Car Name"
+    assert df.data_model["dimension"][0] == "Name"
+    assert new_df.data_model["dimension"][0] == "Car Name"
 
-        assert list(df.unique_values.values()) == list(new_df.unique_values.values())
-        assert list(df.cardinality.values()) == list(new_df.cardinality.values())
-        assert df._min_max == new_df._min_max
-        assert df.pre_aggregated == new_df.pre_aggregated
-def test_rename2():
+    assert list(df.unique_values.values()) == list(new_df.unique_values.values())
+    assert list(df.cardinality.values()) == list(new_df.cardinality.values())
+    assert df._min_max == new_df._min_max
+    assert df.pre_aggregated == new_df.pre_aggregated
+def test_rename3():
 
     url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
     df = pd.read_csv(url)


### PR DESCRIPTION
This pull request fixes issues that cause Lux to error when a column of DataFrame has the `dtype` set to something non-standard (eg. `uint8` or `Int64`). This would relax the condition that a column of integers had to be `int64`; now it can be a column of integers of any size (unsigned or signed).

Also, after studying how Pandas internal functions are called and how often, we decided to expire the metadata almost exclusively inside `getattr` and remove other places of metadata expiration.

However, we also end up expiring the metadata in `_set_axis`. This fixes the bug where the metadata with new column names is propagated after it's renamed with this technique: 
```python
df.columns =  ["col1", "col2", "col3", "col4","col5", "col6", "col7", "col8", "col9", "col10"]
```

Finally, tests for the above bugs were added to the test suite.