### PR TITLE
memoize unfiltered sample

### DIFF
--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -33,6 +33,7 @@ class LuxDataFrame(pd.DataFrame):
 		self.SQLconnection = ""
 		self.table_name = ""
 
+		self._sampled = None
 		self._default_pandas_display = True
 		self._toggle_pandas_display = True
 		self._plot_config = None
@@ -72,7 +73,8 @@ class LuxDataFrame(pd.DataFrame):
 		self.recommendation = None
 		self.current_vis = None
 		self._widget = None
-		self._rec_info= None
+		self._rec_info = None
+		self._sampled = None
 	def expire_metadata(self):
 		# Set metadata as null
 		self._metadata_fresh = False

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -50,12 +50,14 @@ class PandasExecutor(Executor):
                         attributes.add(clause.attribute)
             # General Sampling
             if len(vis.data) > 10000:
-                n_samples = int(len(vis.data)*0.75)
-                vis._vis_data = vis.data[list(attributes)].sample(n = n_samples , random_state = 1)
-            else:
-                vis._vis_data = vis.data[list(attributes)]
-            # vis._vis_data = vis.data[list(attributes)]
-            
+                if (filter_executed):
+                    vis._vis_data = vis.data.sample(frac=0.75 , random_state = 1)
+                else:
+                    if (ldf._sampled is None): # memoize unfiltered sample df 
+                        ldf._sampled = vis.data.sample(frac=0.75 , random_state = 1)
+                    vis._vis_data = ldf._sampled
+            # TODO: Add some type of cap size on Nrows ?
+            vis._vis_data = vis.data[list(attributes)]
             if (vis.mark =="bar" or vis.mark =="line"):
                 PandasExecutor.execute_aggregate(vis,isFiltered = filter_executed)
             elif (vis.mark =="histogram"):


### PR DESCRIPTION
The df.sample operation is fairly expensive and occupies a large percentage of the runtime. 
<img src="https://user-images.githubusercontent.com/5554675/94278207-21209600-ff7d-11ea-890c-ff23ec37438e.png" width=300></img>
We memoize any unfiltered samples generated for the dataframe in order to speed up the recommendations. This avoids many repetitive computation to sample for every visualizations. We only operate on unfiltered samples since the filter step occurs before sampling, so the input dataframe would be different. This yields a few seconds of improvement in runtime for generating the Lux display:

- Airbnb [244475 rows x 12 cols] : 19.29s → 18.14 s

- Flights [855632 rows x 11 cols]:  21.24s → 18.80s


