### PR TITLE
Encode color of chart before adding text

### DIFF
--- a/examples/demo/college_demo.ipynb
+++ b/examples/demo/college_demo.ipynb
@@ -121,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.set_intent([\"AverageCost\"])\n",
+    "df.intent = [\"AverageCost\"]\n",
     "df"
    ]
   },
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.set_intent([\"AverageCost\",\"SATAverage\"])\n",
+    "df.intent = [\"AverageCost\",\"SATAverage\"]\n",
     "df"
    ]
   },

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -594,13 +594,13 @@ class LuxDataFrame(pd.DataFrame):
 				on_button_clicked(None)
 		except(KeyboardInterrupt,SystemExit):
 			raise
-		except:
-			warnings.warn(
-					"\nUnexpected error in rendering Lux widget and recommendations. "
-					"Falling back to Pandas display.\n\n" 
-					"Please report this issue on Github: https://github.com/lux-org/lux/issues "
-				,stacklevel=2)
-			display(self.display_pandas())
+		# except:
+		# 	warnings.warn(
+		# 			"\nUnexpected error in rendering Lux widget and recommendations. "
+		# 			"Falling back to Pandas display.\n\n" 
+		# 			"Please report this issue on Github: https://github.com/lux-org/lux/issues "
+		# 		,stacklevel=2)
+		# 	display(self.display_pandas())
 	def display_pandas(self):
 		return self.to_pandas()
 	def render_widget(self, renderer:str ="altair", input_current_vis=""):

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -594,13 +594,13 @@ class LuxDataFrame(pd.DataFrame):
 				on_button_clicked(None)
 		except(KeyboardInterrupt,SystemExit):
 			raise
-		# except:
-		# 	warnings.warn(
-		# 			"\nUnexpected error in rendering Lux widget and recommendations. "
-		# 			"Falling back to Pandas display.\n\n" 
-		# 			"Please report this issue on Github: https://github.com/lux-org/lux/issues "
-		# 		,stacklevel=2)
-		# 	display(self.display_pandas())
+		except:
+			warnings.warn(
+					"\nUnexpected error in rendering Lux widget and recommendations. "
+					"Falling back to Pandas display.\n\n" 
+					"Please report this issue on Github: https://github.com/lux-org/lux/issues "
+				,stacklevel=2)
+			display(self.display_pandas())
 	def display_pandas(self):
 		return self.to_pandas()
 	def render_widget(self, renderer:str ="altair", input_current_vis=""):

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -15,7 +15,6 @@
 import pandas as pd
 import altair as alt
 from lux.utils.date_utils import compute_date_granularity
-
 class AltairChart:
 	"""
 	AltairChart is a representation of a chart. 
@@ -44,7 +43,7 @@ class AltairChart:
 	def add_tooltip(self):
 		if (self.tooltip): 
 			self.chart = self.chart.encode(tooltip=list(self.vis.data.columns))
-
+			
 	def apply_default_config(self):
 		self.chart = self.chart.configure_title(fontWeight=500,fontSize=13,font="Helvetica Neue")
 		self.chart = self.chart.configure_axis(titleFontWeight=500,titleFontSize=11,titleFont="Helvetica Neue",
@@ -82,8 +81,6 @@ class AltairChart:
 			)
 			if (self.code!=""):
 				self.code+=f"chart = chart.encode().properties(title = '{chart_title}')"
-
 	def initialize_chart(self):
 		return NotImplemented
-	
 	

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -36,8 +36,7 @@ class AltairChart:
 		self.code = "" 
 		self.chart = self.initialize_chart()
 		# self.add_tooltip()
-		self.encode_color() # move this inside initialize_chart()
-		self.add_text()
+		self.encode_color()
 		self.add_title()
 		self.apply_default_config()
 
@@ -85,9 +84,8 @@ class AltairChart:
 			)
 			if (self.code!=""):
 				self.code+=f"chart = chart.encode().properties(title = '{chart_title}')"
+
 	def initialize_chart(self):
 		return NotImplemented
 	
-	def add_text(self):
-		return NotImplemented
 	

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -15,8 +15,6 @@
 import pandas as pd
 import altair as alt
 from lux.utils.date_utils import compute_date_granularity
-from lux.vislib.altair import BarChart
-
 
 class AltairChart:
 	"""

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -15,6 +15,9 @@
 import pandas as pd
 import altair as alt
 from lux.utils.date_utils import compute_date_granularity
+from lux.vislib.altair import BarChart
+
+
 class AltairChart:
 	"""
 	AltairChart is a representation of a chart. 
@@ -33,7 +36,8 @@ class AltairChart:
 		self.code = "" 
 		self.chart = self.initialize_chart()
 		# self.add_tooltip()
-		# self.encode_color() // move this inside initialize_chart()
+		self.encode_color() # move this inside initialize_chart()
+		self.add_text()
 		self.add_title()
 		self.apply_default_config()
 
@@ -58,20 +62,20 @@ class AltairChart:
 		self.code+= "					labelFontWeight=400,labelFontSize=8,labelFont='Helvetica Neue')\n"
 		self.code+= "chart = chart.properties(width=160,height=150)\n"
 
-	# def encode_color(self):
-	# 	color_attr = self.vis.get_attr_by_channel("color")
-	# 	if (len(color_attr)==1):
-	# 		color_attr_name = color_attr[0].attribute
-	# 		color_attr_type = color_attr[0].data_type
-	# 		if (color_attr_type=="temporal"):
-	# 			timeUnit = compute_date_granularity(self.vis.data[color_attr_name])
-	# 			self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type,timeUnit=timeUnit,title=color_attr_name))	
-	# 			self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}',timeUnit='{timeUnit}',title='{color_attr_name}'))"
-	# 		else:
-	# 			self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type))
-	# 			self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}'))\n"
-	# 	elif (len(color_attr)>1):
-	# 		raise ValueError("There should not be more than one attribute specified in the same channel.")
+	def encode_color(self):
+		color_attr = self.vis.get_attr_by_channel("color")
+		if (len(color_attr)==1):
+			color_attr_name = color_attr[0].attribute
+			color_attr_type = color_attr[0].data_type
+			if (color_attr_type=="temporal"):
+				timeUnit = compute_date_granularity(self.vis.data[color_attr_name])
+				self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type,timeUnit=timeUnit,title=color_attr_name))	
+				self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}',timeUnit='{timeUnit}',title='{color_attr_name}'))"
+			else:
+				self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type))
+				self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}'))\n"
+		elif (len(color_attr)>1):
+			raise ValueError("There should not be more than one attribute specified in the same channel.")
 		
 	def add_title(self):
 		chart_title = self.vis.title
@@ -83,3 +87,7 @@ class AltairChart:
 				self.code+=f"chart = chart.encode().properties(title = '{chart_title}')"
 	def initialize_chart(self):
 		return NotImplemented
+	
+	def add_text(self):
+		return NotImplemented
+	

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -33,7 +33,7 @@ class AltairChart:
 		self.code = "" 
 		self.chart = self.initialize_chart()
 		# self.add_tooltip()
-		self.encode_color()
+		# self.encode_color() // move this inside initialize_chart()
 		self.add_title()
 		self.apply_default_config()
 
@@ -58,20 +58,20 @@ class AltairChart:
 		self.code+= "					labelFontWeight=400,labelFontSize=8,labelFont='Helvetica Neue')\n"
 		self.code+= "chart = chart.properties(width=160,height=150)\n"
 
-	def encode_color(self):
-		color_attr = self.vis.get_attr_by_channel("color")
-		if (len(color_attr)==1):
-			color_attr_name = color_attr[0].attribute
-			color_attr_type = color_attr[0].data_type
-			if (color_attr_type=="temporal"):
-				timeUnit = compute_date_granularity(self.vis.data[color_attr_name])
-				self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type,timeUnit=timeUnit,title=color_attr_name))	
-				self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}',timeUnit='{timeUnit}',title='{color_attr_name}'))"
-			else:
-				self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type))
-				self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}'))\n"
-		elif (len(color_attr)>1):
-			raise ValueError("There should not be more than one attribute specified in the same channel.")
+	# def encode_color(self):
+	# 	color_attr = self.vis.get_attr_by_channel("color")
+	# 	if (len(color_attr)==1):
+	# 		color_attr_name = color_attr[0].attribute
+	# 		color_attr_type = color_attr[0].data_type
+	# 		if (color_attr_type=="temporal"):
+	# 			timeUnit = compute_date_granularity(self.vis.data[color_attr_name])
+	# 			self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type,timeUnit=timeUnit,title=color_attr_name))	
+	# 			self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}',timeUnit='{timeUnit}',title='{color_attr_name}'))"
+	# 		else:
+	# 			self.chart = self.chart.encode(color=alt.Color(color_attr_name,type=color_attr_type))
+	# 			self.code+=f"chart = chart.encode(color=alt.Color('{color_attr_name}',type='{color_attr_type}'))\n"
+	# 	elif (len(color_attr)>1):
+	# 		raise ValueError("There should not be more than one attribute specified in the same channel.")
 		
 	def add_title(self):
 		chart_title = self.vis.title

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -43,7 +43,6 @@ class AltairChart:
 	def add_tooltip(self):
 		if (self.tooltip): 
 			self.chart = self.chart.encode(tooltip=list(self.vis.data.columns))
-			
 	def apply_default_config(self):
 		self.chart = self.chart.configure_title(fontWeight=500,fontSize=13,font="Helvetica Neue")
 		self.chart = self.chart.configure_axis(titleFontWeight=500,titleFontSize=11,titleFont="Helvetica Neue",
@@ -83,4 +82,3 @@ class AltairChart:
 				self.code+=f"chart = chart.encode().properties(title = '{chart_title}')"
 	def initialize_chart(self):
 		return NotImplemented
-	

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -57,7 +57,7 @@ class BarChart(AltairChart):
 				x_attr_field.sort="-y"
 				x_attr_field_code = f"alt.X('{x_attr.attribute}', type= '{x_attr.data_type}', axis=alt.Axis(labelOverlap=True),sort='-y')"
 		k=10
-		self.topK_code = ""
+		self._topkcode = ""
 		if len(self.data)>k: # Truncating to only top k
 			remaining_bars = len(self.data)-k
 			self.data = self.data.nlargest(k,measure_attr)
@@ -70,7 +70,7 @@ class BarChart(AltairChart):
 				text=f"+ {remaining_bars} more ..."
 			)
 
-			self.topK_code = f'''text = alt.Chart(visData).mark_text(
+			self._topkcode = f'''text = alt.Chart(visData).mark_text(
 			x=155, 
 			y=142,
 			align="right",
@@ -78,8 +78,7 @@ class BarChart(AltairChart):
 			fontSize = 11,
 			text=f"+ {remaining_bars} more ..."
 		)
-		chart = chart + text
-			'''
+		chart = chart + text\n'''
 		
 		chart = alt.Chart(self.data).mark_bar().encode(
 			    y = y_attr_field,
@@ -96,18 +95,16 @@ class BarChart(AltairChart):
 		chart = alt.Chart(visData).mark_bar().encode(
 		    y = {y_attr_field_code},
 		    x = {x_attr_field_code},
-		)
-			'''
+		)\n'''
 		return chart 
 	
 	def add_text(self):
-		if (self.topK_code!=""):
+		if (self._topkcode!=""):
 			self.chart = self.chart + self.text
-			self.code += self.topK_code
+			self.code += self._topkcode
 	
-	def encode_color(self): # override encode_color so that it adds text after
+	def encode_color(self): # override encode_color in AltairChart to enforce add_text occurs afterwards
 		AltairChart.encode_color(self)
 		self.add_text()
 		self.chart = self.chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null
-		self.code += f'''chart = chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null 
-		'''
+		self.code += f'''chart = chart.configure_mark(tooltip=alt.TooltipContent('encoding'))'''

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -37,7 +37,7 @@ class BarChart(AltairChart):
 		
 		if (x_attr.data_model == "measure"):
 			agg_title = get_agg_title(x_attr)
-			self.measure_attr = x_attr.attribute
+			measure_attr = x_attr.attribute
 			y_attr_field = alt.Y(y_attr.attribute, type= y_attr.data_type, axis=alt.Axis(labelOverlap=True))
 			x_attr_field = alt.X(x_attr.attribute, type= x_attr.data_type, title=agg_title)
 			y_attr_field_code = f"alt.Y('{y_attr.attribute}', type= '{y_attr.data_type}', axis=alt.Axis(labelOverlap=True))"
@@ -48,7 +48,7 @@ class BarChart(AltairChart):
 				y_attr_field_code = f"alt.Y('{y_attr.attribute}', type= '{y_attr.data_type}', axis=alt.Axis(labelOverlap=True), sort ='-x')"
 		else:
 			agg_title = get_agg_title(y_attr)
-			self.measure_attr = y_attr.attribute
+			measure_attr = y_attr.attribute
 			x_attr_field = alt.X(x_attr.attribute, type = x_attr.data_type,axis=alt.Axis(labelOverlap=True))
 			y_attr_field = alt.Y(y_attr.attribute,type=y_attr.data_type,title=agg_title)
 			x_attr_field_code = f"alt.X('{x_attr.attribute}', type= '{x_attr.data_type}', axis=alt.Axis(labelOverlap=True))"
@@ -61,7 +61,7 @@ class BarChart(AltairChart):
 		self.topK_code = ""
 		if len(self.data)>k: # Truncating to only top k
 			remaining_bars = len(self.data)-k
-			self.data = self.data.nlargest(k,self.measure_attr)
+			self.data = self.data.nlargest(k,measure_attr)
 			self.text = alt.Chart(self.data).mark_text(
 				x=155, 
 				y=142,
@@ -90,7 +90,7 @@ class BarChart(AltairChart):
 		# TODO: tooltip messes up the count() bar charts		
 		# Can not do interactive whenever you have default count measure otherwise output strange error (Javascript Error: Cannot read property 'length' of undefined)
 		#chart = chart.interactive() # If you want to enable Zooming and Panning
-		# chart = chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null
+		
 
 		self.code += "import altair as alt\n"
 		# self.code += f"visData = pd.DataFrame({str(self.data.to_dict(orient='records'))})\n"
@@ -100,7 +100,6 @@ class BarChart(AltairChart):
 		    y = {y_attr_field_code},
 		    x = {x_attr_field_code},
 		)
-		chart = chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null
 			'''
 		return chart 
 	
@@ -109,6 +108,11 @@ class BarChart(AltairChart):
 			self.chart = self.chart + self.text
 			self.code += self.topK_code
 	
-	def encode_color(self): # overridde encode_color so that it adds text after
+	def encode_color(self): # override encode_color so that it adds text after
 		AltairChart.encode_color(self)
 		self.add_text()
+		self.chart = self.chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null
+		self.code += f'''chart = chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null 
+		'''
+
+

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -57,6 +57,30 @@ class BarChart(AltairChart):
 				x_attr_field.sort="-y"
 				x_attr_field_code = f"alt.X('{x_attr.attribute}', type= '{x_attr.data_type}', axis=alt.Axis(labelOverlap=True),sort='-y')"
 	
+		k=10
+		self.topK_code = ""
+		if len(self.data)>k: # Truncating to only top k
+			remaining_bars = len(self.data)-k
+			self.data = self.data.nlargest(k,self.measure_attr)
+			self.text = alt.Chart(self.data).mark_text(
+				x=155, 
+				y=142,
+				align="right",
+				color = "#ff8e04",
+				fontSize = 11,
+				text=f"+ {remaining_bars} more ..."
+			)
+
+			self.topK_code = f'''text = alt.Chart(visData).mark_text(
+			x=155, 
+			y=142,
+			align="right",
+			color = "#ff8e04",
+			fontSize = 11,
+			text=f"+ {remaining_bars} more ..."
+		)
+		chart = chart + text
+			'''
 		
 		chart = alt.Chart(self.data).mark_bar().encode(
 			    y = y_attr_field,
@@ -77,35 +101,14 @@ class BarChart(AltairChart):
 		    x = {x_attr_field_code},
 		)
 		chart = chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null
-		'''
+			'''
 		return chart 
 	
 	def add_text(self):
-		k=10
-		topK_code = ""
-		if len(self.data)>k: # Truncating to only top k
-			remaining_bars = len(self.data)-k
-			self.data = self.data.nlargest(k,self.measure_attr)
-			text = alt.Chart(self.data).mark_text(
-				x=155, 
-				y=142,
-				align="right",
-				color = "#ff8e04",
-				fontSize = 11,
-				text=f"+ {remaining_bars} more ..."
-			)
-
-			topK_code = f'''text = alt.Chart(visData).mark_text(
-			x=155, 
-			y=142,
-			align="right",
-			color = "#ff8e04",
-			fontSize = 11,
-			text=f"+ {remaining_bars} more ..."
-		)
-		chart = chart + text
-			'''
-		
-		if (topK_code!=""):
-			self.chart = self.chart + text
-			self.code += topK_code
+		if (self.topK_code!=""):
+			self.chart = self.chart + self.text
+			self.code += self.topK_code
+	
+	def encode_color(self): # overridde encode_color so that it adds text after
+		AltairChart.encode_color(self)
+		self.add_text()

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -56,7 +56,6 @@ class BarChart(AltairChart):
 			if (x_attr.sort=="ascending"):
 				x_attr_field.sort="-y"
 				x_attr_field_code = f"alt.X('{x_attr.attribute}', type= '{x_attr.data_type}', axis=alt.Axis(labelOverlap=True),sort='-y')"
-	
 		k=10
 		self.topK_code = ""
 		if len(self.data)>k: # Truncating to only top k
@@ -86,12 +85,10 @@ class BarChart(AltairChart):
 			    y = y_attr_field,
 			    x = x_attr_field
 			)
-
 		# TODO: tooltip messes up the count() bar charts		
 		# Can not do interactive whenever you have default count measure otherwise output strange error (Javascript Error: Cannot read property 'length' of undefined)
 		#chart = chart.interactive() # If you want to enable Zooming and Panning
 		
-
 		self.code += "import altair as alt\n"
 		# self.code += f"visData = pd.DataFrame({str(self.data.to_dict(orient='records'))})\n"
 		self.code += f"visData = pd.DataFrame({str(self.data.to_dict())})\n"
@@ -114,5 +111,3 @@ class BarChart(AltairChart):
 		self.chart = self.chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null
 		self.code += f'''chart = chart.configure_mark(tooltip=alt.TooltipContent('encoding')) # Setting tooltip as non-null 
 		'''
-
-

--- a/tests/test_pandas_coverage.py
+++ b/tests/test_pandas_coverage.py
@@ -21,8 +21,7 @@ import pandas as pd
 ###################
 
 def test_deepcopy():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
     df._repr_html_();
     saved_df = df.copy(deep=True)
@@ -30,8 +29,7 @@ def test_deepcopy():
     check_metadata_equal(df, saved_df)
 
 def test_rename_inplace():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
     df._repr_html_();
     new_df = df.copy(deep=True)
@@ -63,8 +61,7 @@ def test_rename_inplace():
     assert df._min_max == new_df._min_max
     assert df.pre_aggregated == new_df.pre_aggregated
 def test_rename():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y') 
     df._repr_html_();
     new_df = df.rename(columns={"Name": "Car Name"}, inplace = False)
@@ -93,19 +90,17 @@ def test_rename():
     assert df.pre_aggregated == new_df.pre_aggregated
 def test_rename3():
 
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
-    df.columns = ["col1", "col2", "col3", "col4","col5", "col6", "col7", "col8", "col9", "col10"]
+    df.columns = ["col1", "col2", "col3", "col4","col5", "col6", "col7", "col8", "col9"]
     df._repr_html_()
     assert list(df.recommendation.keys() ) == ['Correlation', 'Distribution', 'Occurrence', 'Temporal'] 
-    assert len(df.cardinality) == 10
+    assert len(df.cardinality) == 9
     assert "col2" in list(df.cardinality.keys())
 
 def test_concat():
 
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     new_df = pd.concat([df.loc[:, "Name":"Cylinders"], df.loc[:, "Year":"Origin"]], axis = "columns")
     new_df._repr_html_()
@@ -192,8 +187,7 @@ def test_applymap():
     assert len(df.cardinality) == 9
 
 def test_strcat():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv('https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true')
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     df["combined"] = df["Origin"].str.cat(df["Brand"], sep = ", ")
     df._repr_html_()
@@ -201,8 +195,7 @@ def test_strcat():
     assert len(df.cardinality) == 11
 
 def test_named_agg():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv('https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true')
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     new_df = df.groupby("Brand").agg(avg_weight = ("Weight", "mean"), max_weight = ("Weight", "max"), mean_displacement = ("Displacement", "mean"))
     new_df._repr_html_()
@@ -235,14 +228,13 @@ def test_drop():
     assert len(new_df2.cardinality) == 6
 
 def test_merge():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv("lux/data/car.csv")
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     new_df = df.drop([0, 1, 2], axis = "rows")
     new_df2 = pd.merge(df, new_df, how = "left", indicator = True)
     new_df2._repr_html_()
     assert list(new_df2.recommendation.keys() ) == ['Correlation', 'Distribution', 'Occurrence', 'Temporal']  # TODO once bug is fixed
-    assert len(new_df2.cardinality) == 11 # TODO once bug is fixed
+    assert len(new_df2.cardinality) == 10
 
 def test_prefix():
     df = pd.read_csv("lux/data/car.csv")
@@ -254,8 +246,7 @@ def test_prefix():
     assert new_df.cardinality["1_Name"] == 300
 
 def test_loc():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv('https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true')
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     new_df = df.loc[:,"Displacement":"Origin"]
     new_df._repr_html_()
@@ -277,8 +268,7 @@ def test_loc():
     assert len(new_df.cardinality) == 3
 
 def test_iloc():
-    url = 'https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true'
-    df = pd.read_csv(url)
+    df = pd.read_csv('https://github.com/lux-org/lux-datasets/blob/master/data/cars.csv?raw=true')
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     new_df = df.iloc[:,3:9]
     new_df._repr_html_()

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -159,3 +159,10 @@ def test_vis_list_set_intent():
     vislist.intent = ["Weight","?"]
     vislist._repr_html_()
     for vis in vislist: assert vis.get_attr_by_attr_name("Weight")!=[]
+def test_text_not_overridden():
+    from lux.vis.Vis import Vis
+    df = pd.read_csv("lux/data/college.csv")
+    vis = Vis(["Region", "Geography"], df)
+    # vis._repr_html_()
+    code = vis.to_Altair()
+    assert "color = \"#ff8e04\"" in code

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -163,6 +163,6 @@ def test_text_not_overridden():
     from lux.vis.Vis import Vis
     df = pd.read_csv("lux/data/college.csv")
     vis = Vis(["Region", "Geography"], df)
-    # vis._repr_html_()
+    vis._repr_html_()
     code = vis.to_Altair()
     assert "color = \"#ff8e04\"" in code


### PR DESCRIPTION
This PR solves #108 where the text attribute was getting overridden by the encoding color. Since encoding takes priority over any attributes we set on the chart, the fix, as recommended by https://github.com/altair-viz/altair/issues/1033 is to encode the chart separately from the text. I overrode the `encode_color()` method in `BarChart.py` by adding the text after the encoding. All other graphs behave the same way. 

<img width="920" alt="Screen Shot 2020-10-18 at 10 37 13 PM" src="https://user-images.githubusercontent.com/46768380/96405678-ac630500-1192-11eb-93e7-98b6865b66f6.png">


