### PR TITLE
Fixes issue where value_counts was not returning LuxSeries

### DIFF
--- a/lux/action/default.py
+++ b/lux/action/default.py
@@ -7,7 +7,6 @@ def register_default_actions():
     from lux.action.filter import add_filter
     from lux.action.generalize import generalize
 
-    print("Register default actions")
     # display conditions for default actions
     no_vis = lambda ldf: (ldf.current_vis is None) or (
         ldf.current_vis is not None and len(ldf.current_vis) == 0

--- a/lux/core/__init__.py
+++ b/lux/core/__init__.py
@@ -57,7 +57,7 @@ def setOption(overridePandas=True):
         ) = (
             pd.io.spss.DataFrame
         ) = pd.io.stata.DataFrame = pd.io.api.DataFrame = pd.core.frame.DataFrame = LuxDataFrame
-        pd.Series = LuxSeries
+        pd.Series = pd.core.series.Series = LuxSeries
     else:
         pd.DataFrame = pd.io.parsers.DataFrame = pd.core.frame.DataFrame = originalDF
         pd.Series = originalSeries

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -88,7 +88,8 @@ class LuxSeries(pd.Series):
             # 1) Values of the series are of dtype objects (df.dtypes)
             is_dtype_series = all(isinstance(val, np.dtype) for val in self.values)
             # 2) Mixed type, often a result of a "row" acting as a series (df.iterrows, df.iloc[0])
-            mixed_dtype = len(set([type(val) for val in self.values])) > 1
+            # Tolerant for NaNs + 1 type
+            mixed_dtype = len(set([type(val) for val in self.values])) > 2
             if ldf._pandas_only or is_dtype_series or mixed_dtype:
                 print(series_repr)
                 ldf._pandas_only = False

--- a/tests/test_pandas_coverage.py
+++ b/tests/test_pandas_coverage.py
@@ -653,7 +653,10 @@ def test_str_replace(global_var):
     assert df.cardinality is not None, "Metadata is lost when going from Dataframe to Series."
     assert series.name == "Brand", "Pandas Series original `name` property not retained."
 
-
+def test_value_counts(global_var):
+    df = pd.read_csv("lux/data/car.csv")
+    df._repr_html_()
+    assert type(df['Brand'].value_counts()) == lux.core.series.LuxSeries
 ################
 # Read Tests #
 ################

--- a/tests/test_pandas_coverage.py
+++ b/tests/test_pandas_coverage.py
@@ -605,7 +605,7 @@ def test_value_counts(global_var):
     assert df.cardinality is not None
     series = df["Weight"]
     series.value_counts()
-    assert isinstance(series, lux.core.series.LuxSeries), "Derived series is type LuxSeries."
+    assert type(df["Brand"].value_counts()) == lux.core.series.LuxSeries
     assert df["Weight"]._metadata == [
         "_intent",
         "data_type",
@@ -652,12 +652,6 @@ def test_str_replace(global_var):
     ], "Metadata is lost when going from Dataframe to Series."
     assert df.cardinality is not None, "Metadata is lost when going from Dataframe to Series."
     assert series.name == "Brand", "Pandas Series original `name` property not retained."
-
-
-def test_value_counts(global_var):
-    df = pd.read_csv("lux/data/car.csv")
-    df._repr_html_()
-    assert type(df["Brand"].value_counts()) == lux.core.series.LuxSeries
 
 
 ################

--- a/tests/test_pandas_coverage.py
+++ b/tests/test_pandas_coverage.py
@@ -653,10 +653,13 @@ def test_str_replace(global_var):
     assert df.cardinality is not None, "Metadata is lost when going from Dataframe to Series."
     assert series.name == "Brand", "Pandas Series original `name` property not retained."
 
+
 def test_value_counts(global_var):
     df = pd.read_csv("lux/data/car.csv")
     df._repr_html_()
-    assert type(df['Brand'].value_counts()) == lux.core.series.LuxSeries
+    assert type(df["Brand"].value_counts()) == lux.core.series.LuxSeries
+
+
 ################
 # Read Tests #
 ################


### PR DESCRIPTION
`series.value_counts()` was returning `pd.core.series.Series` instead of a `LuxSeries`. 

```python
import pandas as pd
df = pd.read_csv("https://github.com/chiphuyen/just-pandas-things/blob/master/data/interviews.csv?raw=True")
series = df.Company.value_counts()
```

![image](https://user-images.githubusercontent.com/32151899/104081409-31cee200-51e3-11eb-99c7-90310f7ba0e4.png)

This was fixed by adding an equality to the `__init__` file that has `pd.core.series.Series` point to `LuxSeries`. 

This PR also fixes the `value_counts` test that didn't catch this issue.