### PR TITLE
Version lock for jupyter-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.7"
 install:
-  - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
   - pip install git+https://github.com/lux-org/lux-widget
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
   - pip install -r requirements-dev.txt
   - pip freeze
-  - pip install parso==0.8.1
+  - pip install jupyter-client==6.1.6
   - pip install git+https://github.com/lux-org/lux-widget
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: python
 python:
   - "3.7"
 install:
-  - pip install -r requirements-dev.txt
-  - pip freeze
   - pip install jupyter-client==6.1.6
-  - pip install git+https://github.com/lux-org/lux-widget
+  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
 # command to run tests
 script:
   - black --target-version py37 --line-length 105 --check .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "3.7"
 install:
   - pip install -r requirements-dev.txt
+  - pip freeze
+  - pip install parso==0.8.1
   - pip install git+https://github.com/lux-org/lux-widget
 # command to run tests
 script:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,3 @@
-scipy>=1.3.3
-altair>=4.0.0
-numpy>=1.16.5
-pandas>=1.1.0
-scikit-learn>=0.22
-
 pytest>=5.3.1
 pytest-cov>=2.8.1
 Sphinx>=3.0.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,9 @@
+scipy>=1.3.3
+altair>=4.0.0
+numpy>=1.16.5
+pandas>=1.1.0
+scikit-learn>=0.22
+
 pytest>=5.3.1
 pytest-cov>=2.8.1
 Sphinx>=3.0.2


### PR DESCRIPTION
An update for jupyter-client breaks the build process on Travis (and other Linux systems), due to this new change that [enforces a minimum requirement on jedi](https://github.com/jupyter/jupyter_client/pull/596). We add a version lock for jupyter-client (v6.1.6) to avoid this issue. This is also implemented in [lux-widget](https://github.com/lux-org/lux-widget), where the error is showing up.
![image](https://user-images.githubusercontent.com/5554675/104082966-7c993a00-5275-11eb-93b8-e1f6034af72b.png)
