### PR TITLE
Temporal type detection for integers via PandasExecutor._is_datetime_number

### DIFF
--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -389,13 +389,11 @@ class PandasExecutor(Executor):
         ldf.data_type = {}
         self.compute_data_type(ldf)
 
-    
-
     def compute_data_type(self, ldf: LuxDataFrame):
         from pandas.api.types import is_datetime64_any_dtype as is_datetime
 
         for attr in list(ldf.columns):
-            temporal_var_list = ["month", "year", "day", "date", "time"]
+            temporal_var_list = ["month", "year", "day", "date", "time", "weekday"]
             if is_datetime(ldf[attr]):
                 ldf.data_type[attr] = "temporal"
             elif self._is_datetime_string(ldf[attr]):

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -211,7 +211,10 @@ class PandasExecutor(Executor):
                             }
                         )
                         vis._vis_data = vis.data.merge(
-                            df, on=[columns[0], columns[1]], how="right", suffixes=["", "_right"],
+                            df,
+                            on=[columns[0], columns[1]],
+                            how="right",
+                            suffixes=["", "_right"],
                         )
                         for col in columns[2:]:
                             vis.data[col] = vis.data[col].fillna(0)  # Triggers __setitem__
@@ -359,7 +362,10 @@ class PandasExecutor(Executor):
                 if color_attr.data_type == "nominal":
                     # Compute mode and count. Mode aggregates each cell by taking the majority vote for the category variable. In cases where there is ties across categories, pick the first item (.iat[0])
                     result = groups.agg(
-                        [("count", "count"), (color_attr.attribute, lambda x: pd.Series.mode(x).iat[0]),]
+                        [
+                            ("count", "count"),
+                            (color_attr.attribute, lambda x: pd.Series.mode(x).iat[0]),
+                        ]
                     ).reset_index()
                 elif color_attr.data_type == "quantitative":
                     # Compute the average of all values in the bin
@@ -467,8 +473,6 @@ class PandasExecutor(Executor):
                     datetime_col = pd.to_datetime(series)
                 except Exception as e:
                     return False
-
-            print(datetime_col)
             if datetime_col is not None:
                 return True
         return False

--- a/tests/test_type.py
+++ b/tests/test_type.py
@@ -124,6 +124,21 @@ def test_check_datetime():
     }
 
 
+def test_check_datetime_numeric_values():
+    car_df = pd.read_csv("lux/data/car.csv")
+    car_df = car_df.rename(columns={"Year": "blah"})
+    car_df.maintain_metadata()
+    assert car_df.data_type["blah"] == "temporal"
+
+    spotify_df = pd.read_csv(
+        "https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/spotify.csv"
+    )
+    spotify_df = spotify_df.rename(columns={"year": "blah"})
+    spotify_df.maintain_metadata()
+    assert spotify_df.data_type["blah"] == "temporal"
+    assert spotify_df.data_type["release_date"] == "temporal"
+
+
 def test_check_stock():
     df = pd.read_csv("https://github.com/lux-org/lux-datasets/blob/master/data/stocks.csv?raw=true")
     df.maintain_metadata()


### PR DESCRIPTION
## In this PR

Closes #218 by adding a datetime validator, `_is_datetime_number(series)`, which takes in a series, checks if it's numerical, and outputs whether the numerical values (e.g. year, date) can be interpreted as datetimes. 
- It does so without the need for Regex, by using the Pandas built-in `to_datetime()` function which raises an exception if the input is likely, not interpretable as a datetime (e.g. year is way past the current date, the number is negative). 
- Numerical values representing the day of the week or month of the year are currently not interpreted as a temporal type unless the column name is "day" or "month". The argument here is that it's difficult to conclude that such a common range of values (e.g 1 - 30) are absolutely temporal.  

## Changes
- Implementation for `PandasExecutor._is_datetime_number()`. 
- Tests in `tests/test_type.py` for correctness and failure cases

## Example Output
![Screen Shot 2021-01-15 at 1 19 21 PM](https://user-images.githubusercontent.com/44735047/104779649-4dcb0a00-5734-11eb-853e-05e2f7a0afff.png)
