### PR TITLE
Prevent current_vis from expiring upon Pandas write operations

### DIFF
--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -125,7 +125,6 @@ class LuxDataFrame(pd.DataFrame):
         """
         self._recs_fresh = False
         self._recommendation = {}
-        self.current_vis = None
         self._widget = None
         self._rec_info = None
         self._sampled = None

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -259,3 +259,18 @@ def test_similarity2():
         )
     )[0]
     assert morrisville_vis.score > watertown_vis.score
+
+
+def test_intent_retained():
+    df = pd.read_csv("https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/employee.csv")
+    df.intent = ["Attrition"]
+    df._repr_html_()
+
+    df["%WorkingYearsAtCompany"] = df["YearsAtCompany"] / df["TotalWorkingYears"]
+    assert df.current_vis != None
+    assert df.intent != None
+    assert df._recs_fresh == False
+    assert df._metadata_fresh == False
+
+    df._repr_html_()
+    assert list(df.recommendation.keys()) == ["Enhance", "Filter"]


### PR DESCRIPTION
Improve expire recommendation strategy so that current_vis does not expire when the recommendations expire in `expire_recs`. The `current_vis` only changes when the intent is set explicitly. In the test example, when a Pandas write operation is performed, the recommendations are expired, but the `current_vis` is unchanged.
