### PR TITLE
Display better warnings when no recommendations are generated

### DIFF
--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -429,7 +429,7 @@ class LuxDataFrame(pd.DataFrame):
         if recommendations["collection"] is not None and len(recommendations["collection"]) > 0:
             rec_infolist.append(recommendations)
 
-    def maintain_recs(self, is_series=False):
+    def maintain_recs(self, is_series="DataFrame"):
         # `rec_df` is the dataframe to generate the recommendations on
         # check to see if globally defined actions have been registered/removed
         if lux.config.update_actions["flag"] == True:
@@ -449,30 +449,16 @@ class LuxDataFrame(pd.DataFrame):
             rec_df._message = Message()
         # Add warning message if there exist ID fields
         if len(rec_df) == 0:
-            if is_series:
-                rec_df._message.add(
-                    f"Lux cannot operate on an empty Series."
-                )
-            else:
-                rec_df._message.add(
-                    f"Lux cannot operate on an empty DataFrame."
+            rec_df._message.add(
+                    f"Lux cannot operate on an empty {is_series}."
                 )
         elif len(rec_df) < 5 and not rec_df.pre_aggregated:
-            if is_series:
-                rec_df._message.add(f"The Series is too small to visualize. To generate visualizations in Lux, the Series must contain at least 5 rows.")
-            else:
-                rec_df._message.add(f"The DataFrame is too small to visualize. To generate visualizations in Lux, the DataFrame must contain at least 5 rows.")
+            rec_df._message.add(f"The {is_series} is too small to visualize. To generate visualizations in Lux, the {is_series} must contain at least 5 rows.")
         elif self.index.nlevels >= 2 or self.columns.nlevels >= 2:
-            if is_series:
-                rec_df._message.add(f"Lux does not currently support Series "
-                        "with hierarchical indexes.\n"
-                        "Please convert the Series into a flat "
-                        "table via pandas.DataFrame.reset_index.")
-            else:
-                rec_df._message.add(f"Lux does not currently support DataFrames "
-                        "with hierarchical indexes.\n"
-                        "Please convert the DataFrame into a flat "
-                        "table via pandas.DataFrame.reset_index.")
+            rec_df._message.add(f"Lux does not currently support visualizations in a {is_series} "
+                    f"with hierarchical indexes.\n"
+                    f"Please convert the {is_series} into a flat "
+                    f"table via pandas.DataFrame.reset_index.")
         else:
             id_fields_str = ""
             inverted_data_type = lux.config.executor.invert_data_type(rec_df.data_type)

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -449,12 +449,14 @@ class LuxDataFrame(pd.DataFrame):
             rec_df = self
             rec_df._message = Message()
         # Add warning message if there exist ID fields
-        if (len(rec_df) == 0):
+        if len(rec_df) == 0:
             rec_df._message.add(
-                f"Lux cannot operate on empty DataFrames or Series; Lux requires at least 5 data points to suggest visualizations.")
-        elif (len(rec_df)<5):
+                f"Lux cannot operate on empty DataFrames or Series; Lux requires at least 5 data points to suggest visualizations."
+            )
+        elif len(rec_df) < 5:
             rec_df._message.add(
-                f"Lux could not compute any actions because the DataFrame or Series is too small (less than 5 data points).")
+                f"Lux could not compute any actions because the DataFrame or Series is too small (less than 5 data points)."
+            )
         else:
             id_fields_str = ""
             inverted_data_type = lux.config.executor.invert_data_type(rec_df.data_type)
@@ -498,7 +500,7 @@ class LuxDataFrame(pd.DataFrame):
         # re-render widget for the current dataframe if previous rec is not recomputed
         elif show_prev:
             self._widget = rec_df.render_widget()
-        
+
         self._recs_fresh = True
 
     #######################################################
@@ -659,7 +661,6 @@ class LuxDataFrame(pd.DataFrame):
                 self._widget.observe(self.remove_deleted_recs, names="deletedIndices")
                 self._widget.observe(self.set_intent_on_click, names="selectedIntentIndex")
 
-
                 button = widgets.Button(
                     description="Toggle Pandas/Lux",
                     layout=widgets.Layout(width="140px", top="5px"),
@@ -681,7 +682,6 @@ class LuxDataFrame(pd.DataFrame):
 
                 button.on_click(on_button_clicked)
                 on_button_clicked(None)
-
 
         except (KeyboardInterrupt, SystemExit):
             raise

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -52,7 +52,6 @@ class LuxDataFrame(pd.DataFrame):
         "_toggle_pandas_display",
         "_message",
         "_pandas_only",
-        "_recs_fresh",
         "pre_aggregated",
         "_type_override",
     ]
@@ -84,7 +83,7 @@ class LuxDataFrame(pd.DataFrame):
         self._min_max = None
         self.pre_aggregated = None
         self._type_override = {}
-        self._recs_fresh = False
+        # self._recs_fresh = False
         warnings.formatwarning = lux.warning_format
 
     @property

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -83,7 +83,6 @@ class LuxDataFrame(pd.DataFrame):
         self._min_max = None
         self.pre_aggregated = None
         self._type_override = {}
-        # self._recs_fresh = False
         warnings.formatwarning = lux.warning_format
 
     @property

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -449,16 +449,18 @@ class LuxDataFrame(pd.DataFrame):
             rec_df._message = Message()
         # Add warning message if there exist ID fields
         if len(rec_df) == 0:
-            rec_df._message.add(
-                    f"Lux cannot operate on an empty {is_series}."
-                )
+            rec_df._message.add(f"Lux cannot operate on an empty {is_series}.")
         elif len(rec_df) < 5 and not rec_df.pre_aggregated:
-            rec_df._message.add(f"The {is_series} is too small to visualize. To generate visualizations in Lux, the {is_series} must contain at least 5 rows.")
+            rec_df._message.add(
+                f"The {is_series} is too small to visualize. To generate visualizations in Lux, the {is_series} must contain at least 5 rows."
+            )
         elif self.index.nlevels >= 2 or self.columns.nlevels >= 2:
-            rec_df._message.add(f"Lux does not currently support visualizations in a {is_series} "
-                    f"with hierarchical indexes.\n"
-                    f"Please convert the {is_series} into a flat "
-                    f"table via pandas.DataFrame.reset_index.")
+            rec_df._message.add(
+                f"Lux does not currently support visualizations in a {is_series} "
+                f"with hierarchical indexes.\n"
+                f"Please convert the {is_series} into a flat "
+                f"table via pandas.DataFrame.reset_index."
+            )
         else:
             id_fields_str = ""
             inverted_data_type = lux.config.executor.invert_data_type(rec_df.data_type)
@@ -467,11 +469,11 @@ class LuxDataFrame(pd.DataFrame):
                     id_fields_str += f"<code>{id_field}</code>, "
                 id_fields_str = id_fields_str[:-2]
                 rec_df._message.add(f"{id_fields_str} is not visualized since it resembles an ID field.")
-        
+
         rec_df._prev = None  # reset _prev
 
         # Check that recs has not yet been computed
-        if (not hasattr(rec_df, "_recs_fresh") or not rec_df._recs_fresh):
+        if not hasattr(rec_df, "_recs_fresh") or not rec_df._recs_fresh:
             rec_infolist = []
             from lux.action.row_group import row_group
             from lux.action.column_group import column_group
@@ -481,8 +483,11 @@ class LuxDataFrame(pd.DataFrame):
                 if rec_df.columns.name is not None:
                     rec_df._append_rec(rec_infolist, row_group(rec_df))
                 rec_df._append_rec(rec_infolist, column_group(rec_df))
-            elif not (len(rec_df) < 5 and not rec_df.pre_aggregated) and not (self.index.nlevels >= 2 or self.columns.nlevels >= 2):
+            elif not (len(rec_df) < 5 and not rec_df.pre_aggregated) and not (
+                self.index.nlevels >= 2 or self.columns.nlevels >= 2
+            ):
                 from lux.action.custom import custom_actions
+
                 # generate vis from globally registered actions and append to dataframe
                 custom_action_collection = custom_actions(rec_df)
                 for rec in custom_action_collection:

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -130,17 +130,8 @@ class LuxSeries(pd.Series):
                 print(series_repr)
                 ldf._pandas_only = False
             else:
-                if self.index.nlevels >= 2:
-                    warnings.warn(
-                        "\nLux does not currently support series "
-                        "with hierarchical indexes.\n"
-                        "Please convert the series into a flat "
-                        "table via `pandas.DataFrame.reset_index`.\n",
-                        stacklevel=2,
-                    )
-                    print(series_repr)
-                    return ""
-                ldf.maintain_metadata()
+                if not self.index.nlevels >= 2:
+                    ldf.maintain_metadata()
 
                 if lux.config.default_display == "lux":
                     self._toggle_pandas_display = False

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -120,7 +120,9 @@ class LuxSeries(pd.Series):
         try:
             # Ignore recommendations when Series a results of:
             # 1) Values of the series are of dtype objects (df.dtypes)
-            is_dtype_series = all(isinstance(val, np.dtype) for val in self.values) and len(self.values)!=0
+            is_dtype_series = (
+                all(isinstance(val, np.dtype) for val in self.values) and len(self.values) != 0
+            )
             # 2) Mixed type, often a result of a "row" acting as a series (df.iterrows, df.iloc[0])
             # Tolerant for NaNs + 1 type
             mixed_dtype = len(set([type(val) for val in self.values])) > 2

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -140,13 +140,6 @@ class LuxSeries(pd.Series):
                     )
                     print(series_repr)
                     return ""
-                # if len(self) <= 0:
-                #     warnings.warn(
-                #         "\nLux can not operate on an empty series.\nPlease check your input again.\n",
-                #         stacklevel=2,
-                #     )
-                #     print(series_repr)
-                #     return ""
                 ldf.maintain_metadata()
 
                 if lux.config.default_display == "lux":
@@ -155,7 +148,7 @@ class LuxSeries(pd.Series):
                     self._toggle_pandas_display = True
 
                 # df_to_display.maintain_recs() # compute the recommendations (TODO: This can be rendered in another thread in the background to populate self._widget)
-                ldf.maintain_recs()
+                ldf.maintain_recs(is_series=True)
 
                 # Observers(callback_function, listen_to_this_variable)
                 ldf._widget.observe(ldf.remove_deleted_recs, names="deletedIndices")

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -121,7 +121,7 @@ class LuxSeries(pd.Series):
             # 2) Mixed type, often a result of a "row" acting as a series (df.iterrows, df.iloc[0])
             # Tolerant for NaNs + 1 type
             mixed_dtype = len(set([type(val) for val in self.values])) > 2
-            if ldf._pandas_only:
+            if ldf._pandas_only or is_dtype_series or mixed_dtype:
                 print(series_repr)
                 ldf._pandas_only = False
             else:
@@ -156,7 +156,6 @@ class LuxSeries(pd.Series):
                     self._toggle_pandas_display = True
 
                 # df_to_display.maintain_recs() # compute the recommendations (TODO: This can be rendered in another thread in the background to populate self._widget)
-                ldf.show_prev = False
                 ldf.maintain_recs()
 
                 # Observers(callback_function, listen_to_this_variable)

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -125,12 +125,6 @@ class LuxSeries(pd.Series):
                 print(series_repr)
                 ldf._pandas_only = False
             else:
-                if is_dtype_series:
-                    ldf._message.add("Lux could not compute any actions because the Series provided has a cardinality of 1.")
-                    ldf.expire_recs()
-                if mixed_dtype:
-                    ldf._message.add("Lux could not compute any actions because the Series provided has mixed dtype.")
-                    ldf.expire_recs()
                 if self.index.nlevels >= 2:
                     warnings.warn(
                         "\nLux does not currently support series "

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -139,7 +139,7 @@ class LuxSeries(pd.Series):
                     self._toggle_pandas_display = True
 
                 # df_to_display.maintain_recs() # compute the recommendations (TODO: This can be rendered in another thread in the background to populate self._widget)
-                ldf.maintain_recs(is_series=True)
+                ldf.maintain_recs(is_series="Series")
 
                 # Observers(callback_function, listen_to_this_variable)
                 ldf._widget.observe(ldf.remove_deleted_recs, names="deletedIndices")

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -78,6 +78,7 @@ def test_underspecified_single_vis(global_var, test_recs):
 # 	assert len(df.current_vis) == len([vis.get_attr_by_data_model("measure") for vis in df.current_vis]) #should be 25
 # 	test_recs(df, multiple_vis_actions)
 
+
 def test_set_intent_as_vis(global_var, test_recs):
     df = pytest.car_df
     df._repr_html_()

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -77,6 +77,7 @@ def test_underspecified_single_vis(global_var, test_recs):
 # 	df.set_intent([lux.Clause(attribute ="?", data_model="measure"), lux.Clause(attribute ="?", data_model="measure")])
 # 	assert len(df.current_vis) == len([vis.get_attr_by_data_model("measure") for vis in df.current_vis]) #should be 25
 # 	test_recs(df, multiple_vis_actions)
+
 def test_set_intent_as_vis(global_var, test_recs):
     df = pytest.car_df
     df._repr_html_()

--- a/tests/test_error_warning.py
+++ b/tests/test_error_warning.py
@@ -84,4 +84,4 @@ def test_lux_warnings(global_var):
     df["Year"] = pd.to_datetime(df["Year"], format='%Y')
     new_df = df.set_index(["Name", "Cylinders"])
     new_df._repr_html_()
-    assert new_df._widget.message == f'<ul><li>Lux does not currently support DataFrames with hierarchical indexes.\nPlease convert the DataFrame into a flat table via pandas.DataFrame.reset_index.</li></ul>'
+    assert new_df._widget.message == f'<ul><li>Lux does not currently support visualizations in a DataFrame with hierarchical indexes.\nPlease convert the DataFrame into a flat table via pandas.DataFrame.reset_index.</li></ul>'

--- a/tests/test_error_warning.py
+++ b/tests/test_error_warning.py
@@ -30,6 +30,7 @@ def test_export_b4_widget_created(global_var):
     with pytest.warns(UserWarning, match="No widget attached to the dataframe"):
         df.exported
 
+
 def test_multi_vis(global_var):
     df = pytest.college_df
     multivis_msg = "The intent that you specified corresponds to more than one visualization."
@@ -72,16 +73,23 @@ def test_vis_private_properties(global_var):
     with pytest.raises(AttributeError, match="can't set attribute"):
         vis.mark = "some val"
 
+
 # Test DataFrame Properties give Lux Warning but not UserWarning
 def test_lux_warnings(global_var):
     df = pd.DataFrame()
     df._repr_html_()
-    assert df._widget.message == f'<ul><li>Lux cannot operate on an empty DataFrame.</li></ul>'
+    assert df._widget.message == f"<ul><li>Lux cannot operate on an empty DataFrame.</li></ul>"
     df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     df._repr_html_()
-    assert df._widget.message == f'<ul><li>The DataFrame is too small to visualize. To generate visualizations in Lux, the DataFrame must contain at least 5 rows.</li></ul>'
+    assert (
+        df._widget.message
+        == f"<ul><li>The DataFrame is too small to visualize. To generate visualizations in Lux, the DataFrame must contain at least 5 rows.</li></ul>"
+    )
     df = pytest.car_df
-    df["Year"] = pd.to_datetime(df["Year"], format='%Y')
+    df["Year"] = pd.to_datetime(df["Year"], format="%Y")
     new_df = df.set_index(["Name", "Cylinders"])
     new_df._repr_html_()
-    assert new_df._widget.message == f'<ul><li>Lux does not currently support visualizations in a DataFrame with hierarchical indexes.\nPlease convert the DataFrame into a flat table via pandas.DataFrame.reset_index.</li></ul>'
+    assert (
+        new_df._widget.message
+        == f"<ul><li>Lux does not currently support visualizations in a DataFrame with hierarchical indexes.\nPlease convert the DataFrame into a flat table via pandas.DataFrame.reset_index.</li></ul>"
+    )

--- a/tests/test_error_warning.py
+++ b/tests/test_error_warning.py
@@ -71,3 +71,17 @@ def test_vis_private_properties(global_var):
     assert vis.mark == "scatter"
     with pytest.raises(AttributeError, match="can't set attribute"):
         vis.mark = "some val"
+
+# Test DataFrame Properties give Lux Warning but not UserWarning
+def test_lux_warnings(global_var):
+    df = pd.DataFrame()
+    df._repr_html_()
+    assert df._widget.message == f'<ul><li>Lux cannot operate on an empty DataFrame.</li></ul>'
+    df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    df._repr_html_()
+    assert df._widget.message == f'<ul><li>The DataFrame is too small to visualize. To generate visualizations in Lux, the DataFrame must contain at least 5 rows.</li></ul>'
+    df = pytest.car_df
+    df["Year"] = pd.to_datetime(df["Year"], format='%Y')
+    new_df = df.set_index(["Name", "Cylinders"])
+    new_df._repr_html_()
+    assert new_df._widget.message == f'<ul><li>Lux does not currently support DataFrames with hierarchical indexes.\nPlease convert the DataFrame into a flat table via pandas.DataFrame.reset_index.</li></ul>'

--- a/tests/test_error_warning.py
+++ b/tests/test_error_warning.py
@@ -30,13 +30,6 @@ def test_export_b4_widget_created(global_var):
     with pytest.warns(UserWarning, match="No widget attached to the dataframe"):
         df.exported
 
-
-def test_bad_filter(global_var):
-    df = pytest.college_df
-    with pytest.warns(UserWarning, match="Lux can not operate on an empty dataframe"):
-        df[df["Region"] == "asdfgh"]._repr_html_()
-
-
 def test_multi_vis(global_var):
     df = pytest.college_df
     multivis_msg = "The intent that you specified corresponds to more than one visualization."


### PR DESCRIPTION
This PR allows the backend to send messages to the frontend API to be displayed as warnings rather than using UserWarnings which do not comply with Pandas Style.
So far, the only case when no recommendations are shown is when none of the default actions can be completed because the data has too few data points.

## Changed
- actions only computed if length of df > 0
- `_data_type` set to {} instead of `None` to enable fetching from an empty dictionary
- appropriate error messages added
- removed Pandas fallback
- adjust some series condition checks