### PR TITLE
[PATCH] Require Pandas 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 scipy>=1.3.3
 altair>=4.0.0
 numpy>=1.16.5
-pandas>=1.1.0
+pandas>=1.2.0
 scikit-learn>=0.22
 matplotlib>=3.0.0
 # Install only to use SQLExecutor


### PR DESCRIPTION
This PR updates the requirement for the Pandas package to 1.2.0. Otherwise, it causes an unexpected error in `pd.crosstab` and does not accurately create the right visualizations.

