### PR TITLE
Created LuxSQLTable Object

### DIFF
--- a/lux/__init__.py
+++ b/lux/__init__.py
@@ -15,6 +15,7 @@
 # Register the commonly used modules (similar to how pandas does it: https://github.com/pandas-dev/pandas/blob/master/pandas/__init__.py)
 from lux.vis.Clause import Clause
 from lux.core.frame import LuxDataFrame
+from lux.core.sqltable import LuxSQLTable
 from ._version import __version__, version_info
 from lux._config import config
 from lux._config.config import warning_format

--- a/lux/core/sqltable.py
+++ b/lux/core/sqltable.py
@@ -1,0 +1,192 @@
+#  Copyright 2019-2020 The Lux Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pandas as pd
+from lux.core.series import LuxSeries
+from lux.vis.Clause import Clause
+from lux.vis.Vis import Vis
+from lux.vis.VisList import VisList
+from lux.history.history import History
+from lux.utils.date_utils import is_datetime_series
+from lux.utils.message import Message
+from lux.utils.utils import check_import_lux_widget
+from typing import Dict, Union, List, Callable
+
+# from lux.executor.Executor import *
+import warnings
+import traceback
+import lux
+
+
+class LuxSQLTable(lux.LuxDataFrame):
+    """
+    A subclass of pd.DataFrame that supports all dataframe operations while housing other variables and functions for generating visual recommendations.
+    """
+
+    # MUST register here for new properties!!
+    _metadata = [
+        "_intent",
+        "_inferred_intent",
+        "_data_type",
+        "unique_values",
+        "cardinality",
+        "_rec_info",
+        "_min_max",
+        "_current_vis",
+        "_widget",
+        "_recommendation",
+        "_prev",
+        "_history",
+        "_saved_export",
+        "_sampled",
+        "_toggle_pandas_display",
+        "_message",
+        "_pandas_only",
+        "pre_aggregated",
+        "_type_override",
+    ]
+
+    def __init__(self, *args, table_name="", **kw):
+        self._history = History()
+        self._intent = []
+        self._inferred_intent = []
+        self._recommendation = {}
+        self._saved_export = None
+        self._current_vis = []
+        self._prev = None
+        self._widget = None
+        super(LuxSQLTable, self).__init__(*args, **kw)
+        from lux.executor.SQLExecutor import SQLExecutor
+
+        lux.config.executor = SQLExecutor()
+
+        self._sampled = None
+        self._toggle_pandas_display = True
+        self._message = Message()
+        self._pandas_only = False
+        # Metadata
+        self._data_type = {}
+        self.unique_values = None
+        self.cardinality = None
+        self._min_max = None
+        self.pre_aggregated = None
+        self._type_override = {}
+
+        if table_name != "":
+            self.set_SQL_table(table_name)
+        warnings.formatwarning = lux.warning_format
+
+    def set_SQL_table(self, t_name):
+        # function that ties the Lux Dataframe to a SQL database table
+        if self.table_name != "":
+            warnings.warn(
+                f"\nThis dataframe is already tied to a database table. Please create a new Lux dataframe and connect it to your table '{t_name}'.",
+                stacklevel=2,
+            )
+        else:
+            self.table_name = t_name
+        import psycopg2
+
+        try:
+            lux.config.executor.compute_dataset_metadata(self)
+        except Exception as error:
+            error_str = str(error)
+            if f'relation "{t_name}" does not exist' in error_str:
+                warnings.warn(
+                    f"\nThe table '{t_name}' does not exist in your database./",
+                    stacklevel=2,
+                )
+
+    def _repr_html_(self):
+        from IPython.display import display
+        from IPython.display import clear_output
+        import ipywidgets as widgets
+
+        try:
+            if self._pandas_only:
+                display(self.display_pandas())
+                self._pandas_only = False
+            if not self.index.nlevels >= 2 or self.columns.nlevels >= 2:
+                self.maintain_metadata()
+
+                if self._intent != [] and (not hasattr(self, "_compiled") or not self._compiled):
+                    from lux.processor.Compiler import Compiler
+
+                    self.current_vis = Compiler.compile_intent(self, self._intent)
+
+            if lux.config.default_display == "lux":
+                self._toggle_pandas_display = False
+            else:
+                self._toggle_pandas_display = True
+
+            # df_to_display.maintain_recs() # compute the recommendations (TODO: This can be rendered in another thread in the background to populate self._widget)
+            self.maintain_recs()
+
+            # Observers(callback_function, listen_to_this_variable)
+            self._widget.observe(self.remove_deleted_recs, names="deletedIndices")
+            self._widget.observe(self.set_intent_on_click, names="selectedIntentIndex")
+
+            button = widgets.Button(
+                description="Toggle Data Preview/Lux",
+                layout=widgets.Layout(width="200px", top="5px"),
+            )
+            self.output = widgets.Output()
+            lux.config.executor.execute_preview(self)
+            display(button, self.output)
+
+            def on_button_clicked(b):
+                with self.output:
+                    if b:
+                        self._toggle_pandas_display = not self._toggle_pandas_display
+                    clear_output()
+                    if self._toggle_pandas_display:
+                        display(self._sampled.display_pandas())
+                    else:
+                        # b.layout.display = "none"
+                        display(self._widget)
+                        # b.layout.display = "inline-block"
+
+            button.on_click(on_button_clicked)
+            on_button_clicked(None)
+
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            if lux.config.pandas_fallback:
+                warnings.warn(
+                    "\nUnexpected error in rendering Lux widget and recommendations. "
+                    "Falling back to Pandas display.\n"
+                    "Please report the following issue on Github: https://github.com/lux-org/lux/issues \n",
+                    stacklevel=2,
+                )
+                warnings.warn(traceback.format_exc())
+                display(self.display_pandas())
+            else:
+                raise
+
+    # Overridden Pandas Functions
+    def head(self, n: int = 5):
+        return
+
+    def tail(self, n: int = 5):
+        return
+
+    def info(self, *args, **kwargs):
+        return
+
+    def describe(self, *args, **kwargs):
+        return
+
+    def groupby(self, *args, **kwargs):
+        return

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -34,9 +34,8 @@ def test_underspecified_no_vis(global_var, test_recs):
 
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
 
     test_recs(sql_df, no_vis_actions)
     assert len(sql_df.current_vis) == 0
@@ -62,9 +61,8 @@ def test_underspecified_single_vis(global_var, test_recs):
     df.clear_intent()
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     sql_df.set_intent([lux.Clause(attribute="milespergal"), lux.Clause(attribute="weight")])
     test_recs(sql_df, one_vis_actions)
     assert len(sql_df.current_vis) == 1
@@ -118,9 +116,8 @@ def test_set_intent_as_vis(global_var, test_recs):
     test_recs(df, ["Enhance", "Filter", "Generalize"])
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     sql_df._repr_html_()
     vis = sql_df.recommendation["Correlation"][0]
     sql_df.intent = vis
@@ -154,16 +151,14 @@ def test_parse(global_var):
     assert len(vlst) == 3
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vlst = VisList([lux.Clause("origin=?"), lux.Clause(attribute="milespergal")], sql_df)
     assert len(vlst) == 3
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vlst = VisList([lux.Clause("origin=?"), lux.Clause("milespergal")], sql_df)
     assert len(vlst) == 3
 
@@ -187,9 +182,8 @@ def test_underspecified_vis_collection_zval(global_var):
     # assert len(vlst) == 8
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vlst = VisList(
         [
             lux.Clause(attribute="origin", filter_op="=", value="?"),
@@ -228,9 +222,8 @@ def test_sort_bar(global_var):
     assert vis._inferred_intent[1].sort == "ascending"
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vis = Vis(
         [
             lux.Clause(attribute="acceleration", data_model="measure", data_type="quantitative"),
@@ -242,9 +235,8 @@ def test_sort_bar(global_var):
     assert vis._inferred_intent[1].sort == ""
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vis = Vis(
         [
             lux.Clause(attribute="acceleration", data_model="measure", data_type="quantitative"),
@@ -344,9 +336,8 @@ def test_autoencoding_scatter(global_var):
     df.clear_intent()
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     visList = VisList(
         [lux.Clause(attribute="?"), lux.Clause(attribute="milespergal", channel="x")],
         sql_df,
@@ -399,9 +390,8 @@ def test_autoencoding_scatter():
 
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vis = Vis([lux.Clause(attribute="milespergal"), lux.Clause(attribute="weight")], sql_df)
     check_attribute_on_channel(vis, "milespergal", "x")
     check_attribute_on_channel(vis, "weight", "y")
@@ -454,9 +444,8 @@ def test_autoencoding_histogram(global_var):
     # No channel specified
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vis = Vis([lux.Clause(attribute="milespergal", channel="y")], sql_df)
     check_attribute_on_channel(vis, "milespergal", "y")
 
@@ -508,9 +497,8 @@ def test_autoencoding_line_chart(global_var):
 
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vis = Vis([lux.Clause(attribute="year"), lux.Clause(attribute="acceleration")], sql_df)
     check_attribute_on_channel(vis, "year", "x")
     check_attribute_on_channel(vis, "acceleration", "y")
@@ -564,9 +552,8 @@ def test_autoencoding_color_line_chart(global_var):
 
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     intent = [
         lux.Clause(attribute="year"),
         lux.Clause(attribute="acceleration"),
@@ -605,9 +592,8 @@ def test_autoencoding_color_scatter_chart(global_var):
 
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     vis = Vis(
         [
             lux.Clause(attribute="horsepower"),
@@ -660,9 +646,8 @@ def test_populate_options(global_var):
 
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     sql_df.set_intent([lux.Clause(attribute="?"), lux.Clause(attribute="milespergal")])
     col_set = set()
     for specOptions in Compiler.populate_wildcard_options(sql_df._intent, sql_df)["attributes"]:
@@ -704,9 +689,8 @@ def test_remove_all_invalid(global_var):
 
     # test for sql executor
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = pd.DataFrame()
     lux.config.set_SQL_connection(connection)
-    sql_df.set_SQL_table("cars")
+    sql_df = lux.LuxSQLTable(table_name="cars")
     # with pytest.warns(UserWarning,match="duplicate attribute specified in the intent"):
     sql_df.set_intent(
         [

--- a/tests/test_sql_executor.py
+++ b/tests/test_sql_executor.py
@@ -24,7 +24,7 @@ import psycopg2
 
 def test_lazy_execution():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -41,7 +41,7 @@ def test_lazy_execution():
 
 def test_selection():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -56,7 +56,7 @@ def test_selection():
 
 def test_aggregation():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -90,7 +90,7 @@ def test_colored_bar_chart():
     from lux.vis.Vis import Clause
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -113,7 +113,7 @@ def test_colored_line_chart():
     from lux.vis.Vis import Clause
 
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -134,7 +134,7 @@ def test_colored_line_chart():
 
 def test_filter():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -155,7 +155,7 @@ def test_filter():
 
 def test_inequalityfilter():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -183,7 +183,7 @@ def test_inequalityfilter():
 
 def test_binning():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -194,7 +194,7 @@ def test_binning():
 
 def test_record():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -204,7 +204,7 @@ def test_record():
 
 def test_filter_aggregation_fillzero_aligned():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -221,7 +221,7 @@ def test_filter_aggregation_fillzero_aligned():
 
 def test_exclude_attribute():
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("car")
 
@@ -237,7 +237,7 @@ def test_exclude_attribute():
 def test_null_values():
     # checks that the SQLExecutor has filtered out any None or Null values from its metadata
     connection = psycopg2.connect("host=localhost dbname=postgres user=postgres password=lux")
-    sql_df = lux.LuxDataFrame()
+    sql_df = lux.LuxSQLTable()
     lux.config.set_SQL_connection(connection)
     sql_df.set_SQL_table("aug_test_table")
 


### PR DESCRIPTION
Created the LuxSQLTable object to differentiate between Lux' pandas and SQL functionality.

## Overview

Users can create a LuxSQLTable object and specify which table they would like to connect the object to within the constructor. All of Lux' recommendation functionality is still available, but users will not be able to perform pandas operations on the object as no data is stored locally.

## Changes

The new object is within the sqltable.py file and inherits all of Lux' recommendation system functionality from the LuxDataFrame object. The set_SQL_table() function has also been moved from the LuxDataFrame object to the LuxSQLTable object as we now expect users to not connect dataframes to their databases anymore.

In addition to the new LuxSQLTable changes, the corresponding test files in the test suite have been updated to reflect the new syntax.

Here is an example of the syntax used to create a LuxSQLTable object:
![luxsqltable_example](https://user-images.githubusercontent.com/25440626/110976443-bc33df00-8315-11eb-8185-bb459e721ec7.PNG)
