### PR TITLE
Resolve empty vis bug for geographic data types

### DIFF
--- a/lux/vislib/altair/Choropleth.py
+++ b/lux/vislib/altair/Choropleth.py
@@ -69,9 +69,12 @@ class Choropleth(AltairChart):
             alt.Chart(geo_map)
             .mark_geoshape()
             .encode(
-                color=f"{y_attr_abv}:Q",
+                color=f"{str(y_attr.attribute)}:Q",
             )
-            .transform_lookup(lookup="id", from_=alt.LookupData(self.data, x_attr_abv, [y_attr_abv]))
+            .transform_lookup(
+                lookup="id",
+                from_=alt.LookupData(self.data, str(x_attr.attribute), [str(y_attr.attribute)]),
+            )
             .project(type=map_type)
             .properties(
                 width=width, height=height, title=f"Mean of {y_attr_abv} across {geographical_name}"
@@ -91,10 +94,10 @@ df = pd.DataFrame({str(self.data.to_dict())})
 background = {background_str}
 
 		points = alt.Chart({geo_map_str}).mark_geoshape().encode(
-    color='{y_attr_abv}:Q',
+    color='{str(y_attr.attribute)}:Q',
 ).transform_lookup(
     lookup='id',
-    from_=alt.LookupData({dfname}, "{x_attr_abv}", ["{y_attr_abv}"])
+    from_=alt.LookupData({dfname}, "{str(x_attr.attribute)}", ["{str(y_attr.attribute)}"])
 ).project(
     type="{map_type}"
 ).properties(


### PR DESCRIPTION
## Overview

Previously, choropleth visualizations would not appear when `x_attr` or `y_attr` was abbreviated. With this change, all choropleth visualizations should appear as expected. 

## Changes

- Modifications in `vislib/altair/Choropleth.py`

## Example Output

Now, when we run 

```
import pandas as pd
import lux
df = pd.read_csv("https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/hpi.csv")
df
```
we should get the following output with no empty visualizations. 
<img width="983" alt="Screen Shot 2021-03-22 at 3 26 52 PM" src="https://user-images.githubusercontent.com/44735047/112066139-10636e00-8b23-11eb-912e-d679c5a4d80b.png">


