### PR TITLE
Support choropleths for Matplotlib backend via Altair 

### DIFF
--- a/lux/action/univariate.py
+++ b/lux/action/univariate.py
@@ -84,10 +84,13 @@ def univariate(ldf, *args):
             examples = f" (e.g., {possible_attributes[0]})"
         intent = [lux.Clause("?", data_type="geographical"), lux.Clause("?", data_model="measure")]
         intent.extend(filter_specs)
+        long_description = f"Geographical displays choropleths of averages for some geographic attribute{examples}. Visualizations are ranked by diversity of the geographic attribute."
+        if lux.config.plotting_backend == "matplotlib":
+            long_description += " The map visualizations from the 'Geographical' tab are rendered using Altair. Lux does not currently support geographical maps with Matplotlib. If you would like this feature, please leave us a comment at issue #310 (https://github.com/lux-org/lux/issues/310) to let us know!"
         recommendation = {
             "action": "Geographical",
             "description": "Show choropleth maps of <p class='highlight-descriptor'>geographic</p> attributes",
-            "long_description": f"Geographical displays choropleths of averages for some geographic attribute{examples}. Visualizations are ranked by diversity of the geographic attribute. Choropleths ('Geographical' tab) are rendered using Altair. If you would like Matplotlib support for Choropleths, please express so on https://github.com/lux-org/lux/issues/310.",
+            "long_description": long_description,
         }
     elif data_type_constraint == "temporal":
         intent = [lux.Clause("?", data_type="temporal")]

--- a/lux/action/univariate.py
+++ b/lux/action/univariate.py
@@ -87,7 +87,7 @@ def univariate(ldf, *args):
         recommendation = {
             "action": "Geographical",
             "description": "Show choropleth maps of <p class='highlight-descriptor'>geographic</p> attributes",
-            "long_description": f"Occurence displays choropleths of averages for some geographic attribute{examples}. Visualizations are ranked by diversity of the geographic attribute.",
+            "long_description": f"Geographical displays choropleths of averages for some geographic attribute{examples}. Visualizations are ranked by diversity of the geographic attribute. Choropleths ('Geographical' tab) are rendered using Altair. If you would like Matplotlib support for Choropleths, please express so on https://github.com/lux-org/lux/issues/310.",
         }
     elif data_type_constraint == "temporal":
         intent = [lux.Clause("?", data_type="temporal")]

--- a/lux/action/univariate.py
+++ b/lux/action/univariate.py
@@ -84,9 +84,9 @@ def univariate(ldf, *args):
             examples = f" (e.g., {possible_attributes[0]})"
         intent = [lux.Clause("?", data_type="geographical"), lux.Clause("?", data_model="measure")]
         intent.extend(filter_specs)
-        long_description = f"Geographical displays choropleths of averages for some geographic attribute{examples}. Visualizations are ranked by diversity of the geographic attribute."
+        long_description = f"Geographical displays <a href='https://en.wikipedia.org/wiki/Choropleth_map'>choropleths</a> for geographic attribute{examples}, with colors indicating the average measure values. "
         if lux.config.plotting_backend == "matplotlib":
-            long_description += " The map visualizations from the 'Geographical' tab are rendered using Altair. Lux does not currently support geographical maps with Matplotlib. If you would like this feature, please leave us a comment at issue #310 (https://github.com/lux-org/lux/issues/310) to let us know!"
+            long_description += "The map visualizations from the 'Geographical' tab are rendered using <a href='https://altair-viz.github.io/'>Altair</a>. Lux does not currently support geographical maps with Matplotlib. If you would like this feature, please leave us a comment at <a href='https://github.com/lux-org/lux/issues/310'>issue #310</a> to let us know!"
         recommendation = {
             "action": "Geographical",
             "description": "Show choropleth maps of <p class='highlight-descriptor'>geographic</p> attributes",

--- a/lux/vislib/altair/Choropleth.py
+++ b/lux/vislib/altair/Choropleth.py
@@ -37,7 +37,7 @@ class Choropleth(AltairChart):
         super().__init__(dobj)
 
     def __repr__(self):
-        return f"Proportional Symbol Map <{str(self.vis)}>"
+        return f"Choropleth Map <{str(self.vis)}>"
 
     def initialize_chart(self):
         x_attr = self.vis.get_attr_by_channel("x")[0]

--- a/lux/vislib/matplotlib/MatplotlibRenderer.py
+++ b/lux/vislib/matplotlib/MatplotlibRenderer.py
@@ -87,7 +87,7 @@ class MatplotlibRenderer:
 
             warnings.formatwarning = lux.warning_format
             warnings.warn(
-                " Choropleths ('Geographical' tab) are rendered using Altair. If you would like Matplotlib support for Choropleths, please express so on https://github.com/lux-org/lux/issues/310.\n"
+                " Choropleths ('Geographical' tab) are rendered using Altair. If you would like Matplotlib support for Choropleths, please express so on https://github.com/lux-org/lux/issues/310."
             )
             return AltairRenderer().create_vis(vis, False)
         else:

--- a/lux/vislib/matplotlib/MatplotlibRenderer.py
+++ b/lux/vislib/matplotlib/MatplotlibRenderer.py
@@ -26,7 +26,6 @@ from lux.utils.utils import matplotlib_setup
 
 import base64
 from io import BytesIO
-import warnings
 
 
 class MatplotlibRenderer:
@@ -84,10 +83,6 @@ class MatplotlibRenderer:
         elif vis.mark == "heatmap":
             chart = Heatmap(vis, fig, ax)
         elif vis.mark == "geographical":
-            warnings.formatwarning = lux.warning_format
-            warnings.warn(
-                " Choropleths ('Geographical' tab) are rendered using Altair. If you would like Matplotlib support for Choropleths, please express so on https://github.com/lux-org/lux/issues/310."
-            )
             return AltairRenderer().create_vis(vis, False)
         else:
             chart = None

--- a/lux/vislib/matplotlib/MatplotlibRenderer.py
+++ b/lux/vislib/matplotlib/MatplotlibRenderer.py
@@ -20,6 +20,7 @@ from lux.vislib.matplotlib.ScatterChart import ScatterChart
 from lux.vislib.matplotlib.LineChart import LineChart
 from lux.vislib.matplotlib.Histogram import Histogram
 from lux.vislib.matplotlib.Heatmap import Heatmap
+from lux.vislib.altair.AltairRenderer import AltairRenderer
 import matplotlib.pyplot as plt
 from lux.utils.utils import matplotlib_setup
 
@@ -81,9 +82,17 @@ class MatplotlibRenderer:
             chart = LineChart(vis, fig, ax)
         elif vis.mark == "heatmap":
             chart = Heatmap(vis, fig, ax)
+        elif vis.mark == "geographical":
+            import warnings
+
+            warnings.formatwarning = lux.warning_format
+            warnings.warn(
+                " Choropleths ('Geographical' tab) are rendered using Altair. If you would like Matplotlib support for Choropleths, please express so on https://github.com/lux-org/lux/issues/310.\n"
+            )
+            return AltairRenderer().create_vis(vis, False)
         else:
             chart = None
-            return chart
+            # return chart
         if chart:
             plt.tight_layout()
             if lux.config.plotting_style and (

--- a/lux/vislib/matplotlib/MatplotlibRenderer.py
+++ b/lux/vislib/matplotlib/MatplotlibRenderer.py
@@ -26,6 +26,7 @@ from lux.utils.utils import matplotlib_setup
 
 import base64
 from io import BytesIO
+import warnings
 
 
 class MatplotlibRenderer:
@@ -83,8 +84,6 @@ class MatplotlibRenderer:
         elif vis.mark == "heatmap":
             chart = Heatmap(vis, fig, ax)
         elif vis.mark == "geographical":
-            import warnings
-
             warnings.formatwarning = lux.warning_format
             warnings.warn(
                 " Choropleths ('Geographical' tab) are rendered using Altair. If you would like Matplotlib support for Choropleths, please express so on https://github.com/lux-org/lux/issues/310."
@@ -92,7 +91,7 @@ class MatplotlibRenderer:
             return AltairRenderer().create_vis(vis, False)
         else:
             chart = None
-            # return chart
+            return chart
         if chart:
             plt.tight_layout()
             if lux.config.plotting_style and (

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -465,7 +465,7 @@ def test_vegalite_default_actions_registered_2(global_var):
     df["magnitude"] = np.random.randint(0, 20, size=len(df))
     lux.config.plotting_backend = "vegalite"
 
-    # Symbol Map
+    # Choropleth Map
     assert "Geographical" in df.recommendation
     assert len(df.recommendation["Geographical"]) > 0
 
@@ -493,6 +493,28 @@ def test_matplotlib_default_actions_registered(global_var):
     # Line Chart
     assert "Temporal" in df.recommendation
     assert len(df.recommendation["Temporal"]) > 0
+
+    # Scatter Chart
+    assert "Correlation" in df.recommendation
+    assert len(df.recommendation["Correlation"]) > 0
+
+
+def test_matplotlib_default_actions_registered_2(global_var):
+    import numpy as np
+
+    df = pd.read_csv(
+        "https://raw.githubusercontent.com/altair-viz/vega_datasets/master/vega_datasets/_data/airports.csv"
+    )
+    df["magnitude"] = np.random.randint(0, 20, size=len(df))
+    lux.config.plotting_backend = "matplotlib"
+
+    # Choropleth Map
+    assert "Geographical" in df.recommendation
+    assert len(df.recommendation["Geographical"]) > 0
+
+    # Occurrence Chart
+    assert "Occurrence" in df.recommendation
+    assert len(df.recommendation["Occurrence"]) > 0
 
     # Scatter Chart
     assert "Correlation" in df.recommendation


### PR DESCRIPTION
## In this PR

In this PR, we call upon the AltairRenderer and inform users that the choropleths are rendered via the Altair backend when users set their backend to Matplotlib and geographic attributes are detected. 
- If enough users indicate interest in choropleth rendering via matplotlib, we will reopen #310. 
- **Rationale**: Matplotlib doesn't support choropleths out of the box. It would require some [third party library](https://matplotlib.org/stable/thirdpartypackages/index.html#mapping-toolkits) such as Cartopy or Geopandas. While these libraries meet the necessary requirements to add Matplotlib support for choropleths, they are expensive (Cartopy is 14.6 MB, GeoPandas depends on Fiona which is 49 MB). 

## Related Issues

Closes #310. 

## Changes
- Additional code in `MatplotlibRendererer.py`
- Quick modification of repr function in `Choropleth.py` 
- Added corresponding test for choropleths in `test_vis.py`

## Example Output
Now, upon running 
```
lux.config.plotting_backend = "matplotlib"
df = pd.read_csv("https://github.com/covidvis/covid19-vis/blob/master/data/interventionFootprintByState.csv?raw=True",index_col=0)
df
```
we get the following output: 
<img width="978" alt="Screen Shot 2021-03-24 at 6 38 03 PM" src="https://user-images.githubusercontent.com/44735047/112405750-21051700-8cd0-11eb-8ca0-7884e9eaf1f0.png">

The output for the default Altair plotting backend remains the same. 

