### PR TITLE
Update LuxSQLTable __len__() and metadata computation""

### DIFF
--- a/lux/action/correlation.py
+++ b/lux/action/correlation.py
@@ -62,7 +62,7 @@ def correlation(ldf: LuxDataFrame, ignore_transpose: bool = True):
     }
     ignore_rec_flag = False
     # Doesn't make sense to compute correlation if less than 4 data values
-    if ldf._length < 5:
+    if len(ldf) < 5:
         ignore_rec_flag = True
     # Then use the data populated in the vis list to compute score
     for vis in vlist:

--- a/lux/action/univariate.py
+++ b/lux/action/univariate.py
@@ -59,7 +59,7 @@ def univariate(ldf, *args):
             "long_description": f"Distribution displays univariate histogram distributions of all quantitative attributes{examples}. Visualizations are ranked from most to least skewed.",
         }
         # Doesn't make sense to generate a histogram if there is less than 5 datapoints (pre-aggregated)
-        if ldf._length < 5:
+        if len(ldf) < 5:
             ignore_rec_flag = True
     elif data_type_constraint == "nominal":
         possible_attributes = [
@@ -98,7 +98,7 @@ def univariate(ldf, *args):
             "long_description": "Temporal displays line charts for all attributes related to datetimes in the dataframe.",
         }
         # Doesn't make sense to generate a line chart if there is less than 3 datapoints (pre-aggregated)
-        if ldf._length < 3:
+        if len(ldf) < 3:
             ignore_rec_flag = True
     if ignore_rec_flag:
         recommendation["collection"] = []

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -116,7 +116,8 @@ class LuxDataFrame(pd.DataFrame):
         return self._data_type
 
     def maintain_metadata(self):
-        if lux.config.SQLconnection != "" and lux.config.executor.name != "SQL":
+        is_sql_tbl = lux.config.executor.name == "SQLExecutor"
+        if lux.config.SQLconnection != "" and is_sql_tbl:
             from lux.executor.SQLExecutor import SQLExecutor
 
             lux.config.executor = SQLExecutor()
@@ -124,7 +125,7 @@ class LuxDataFrame(pd.DataFrame):
         # Check that metadata has not yet been computed
         if not hasattr(self, "_metadata_fresh") or not self._metadata_fresh:
             # only compute metadata information if the dataframe is non-empty
-            if lux.config.executor.name == "SQLExecutor":
+            if is_sql_tbl:
                 lux.config.executor.compute_dataset_metadata(self)
                 self._infer_structure()
                 self._metadata_fresh = True
@@ -184,14 +185,16 @@ class LuxDataFrame(pd.DataFrame):
         # If the dataframe is very small and the index column is not a range index, then it is likely that this is an aggregated data
         is_multi_index_flag = self.index.nlevels != 1
         not_int_index_flag = not pd.api.types.is_integer_dtype(self.index)
-        small_df_flag = len(self) < 100 and lux.config.executor.name == "PandasExecutor"
+        is_sql_tbl = lux.config.executor.name == "SQLExecutor"
+
+        small_df_flag = len(self) < 100 and is_sql_tbl
         if self.pre_aggregated == None:
             self.pre_aggregated = (is_multi_index_flag or not_int_index_flag) and small_df_flag
             if "Number of Records" in self.columns:
                 self.pre_aggregated = True
             self.pre_aggregated = (
                 "groupby" in [event.name for event in self.history]
-                and lux.config.executor.name == "PandasExecutor"
+                and not is_sql_tbl
             )
 
     @property
@@ -242,7 +245,6 @@ class LuxDataFrame(pd.DataFrame):
         self._intent = Parser.parse(self._intent)
         Validator.validate_intent(self._intent, self)
         self.maintain_metadata()
-        Validator.validate_intent(self._intent, self)
         from lux.processor.Compiler import Compiler
 
         self.current_vis = Compiler.compile_intent(self, self._intent)
@@ -386,6 +388,7 @@ class LuxDataFrame(pd.DataFrame):
 
         # Check that recs has not yet been computed
         if not hasattr(rec_df, "_recs_fresh") or not rec_df._recs_fresh:
+            is_sql_tbl = lux.config.executor.name == "SQLExecutor"
             rec_infolist = []
             from lux.action.row_group import row_group
             from lux.action.column_group import column_group
@@ -398,7 +401,7 @@ class LuxDataFrame(pd.DataFrame):
             elif not (
                 len(rec_df) < 5
                 and not rec_df.pre_aggregated
-                and lux.config.executor.name == "PandasExecutor"
+                and not is_sql_tbl
             ) and not (self.index.nlevels >= 2 or self.columns.nlevels >= 2):
                 from lux.action.custom import custom_actions
 

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -82,7 +82,6 @@ class LuxDataFrame(pd.DataFrame):
         self._toggle_pandas_display = True
         self._message = Message()
         self._pandas_only = False
-        self._length = len(self)
         # Metadata
         self._data_type = {}
         self.unique_values = None

--- a/lux/core/sqltable.py
+++ b/lux/core/sqltable.py
@@ -55,6 +55,8 @@ class LuxSQLTable(lux.LuxDataFrame):
         "_pandas_only",
         "pre_aggregated",
         "_type_override",
+        "_length",
+        "_setup_done",
     ]
 
     def __init__(self, *args, table_name="", **kw):
@@ -64,12 +66,16 @@ class LuxSQLTable(lux.LuxDataFrame):
         lux.config.executor = SQLExecutor()
 
         self._length = 0
+        self._setup_done = False
         if table_name != "":
             self.set_SQL_table(table_name)
         warnings.formatwarning = lux.warning_format
 
-    def len(self):
-        return self._length
+    def __len__(self):
+        if self._setup_done:
+            return self._length
+        else:
+            return super(LuxSQLTable, self).__len__()
 
     def set_SQL_table(self, t_name):
         # function that ties the Lux Dataframe to a SQL database table
@@ -126,7 +132,7 @@ class LuxSQLTable(lux.LuxDataFrame):
                 layout=widgets.Layout(width="200px", top="6px", bottom="6px"),
             )
             self.output = widgets.Output()
-            lux.config.executor.execute_preview(self)
+            self._sampled = lux.config.executor.execute_preview(self)
             display(button, self.output)
 
             def on_button_clicked(b):

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -502,7 +502,8 @@ class PandasExecutor(Executor):
 
     @staticmethod
     def _is_datetime_number(series):
-        if series.dtype == int or "int" in str(series.dtype):
+        is_int_dtype = pd.api.types.is_integer_dtype(series.dtype)
+        if is_int_dtype:
             try:
                 temp = series.astype(str)
                 pd.to_datetime(temp)

--- a/lux/interestingness/interestingness.py
+++ b/lux/interestingness/interestingness.py
@@ -235,7 +235,7 @@ def deviation_from_overall(
         from lux.executor.SQLExecutor import SQLExecutor
 
         v_filter_size = SQLExecutor.get_filtered_size(filter_specs, ldf)
-        v_size = ldf.len()
+        v_size = len(ldf)
         vdata = vis.data
     v_filter = vdata[msr_attribute]
     total = v_filter.sum()

--- a/lux/utils/utils.py
+++ b/lux/utils/utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import pandas as pd
 import matplotlib.pyplot as plt
+import lux
 
 
 def convert_to_list(x):
@@ -83,7 +84,12 @@ def check_if_id_like(df, attribute):
     if is_string:
         # For string IDs, usually serial numbers or codes with alphanumerics have a consistent length (eg., CG-39405) with little deviation. For a high cardinality string field but not ID field (like Name or Brand), there is less uniformity across the string lengths.
         if len(df) > 50:
-            sampled = df[attribute].sample(50, random_state=99)
+            if lux.config.executor.name == "PandasExecutor":
+                sampled = df[attribute].sample(50, random_state=99)
+            else:
+                from lux.executor.SQLExecutor import SQLExecutor
+
+                sampled = SQLExecutor.execute_preview(df, preview_size=50)
         else:
             sampled = df[attribute]
         str_length_uniformity = sampled.apply(lambda x: type(x) == str and len(x)).std() < 3


### PR DESCRIPTION
## Overview

Added __len__() function capability to the LuxSQLTable and updated metadata handling.

## Changes

Made changes to the LuxSQLTable to enable `len(sql_tbl)` functionality. Updated references to the `sql_tbl._length` parameter throughout the code to be replaced by `len(sql_tbl)`. Making these changes also required updating the metadata calculation process for the LuxSQLTable. 

During the initial setup of the LuxSQLTable, it needs to have the same `len()` functionality as the LuxDataFrame. Added a boolean parameter to keep track of which part of setup a LuxSQLTable is in, and this informs `len()` to either return `sql_tbl._length` or the parent class' `len()`.
