### PR TITLE
Fix visualization failure when intent is missing [issue #276]

### DIFF
--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -225,7 +225,7 @@ class LuxDataFrame(pd.DataFrame):
         self.maintain_metadata()
         from lux.processor.Compiler import Compiler
 
-        self.current_vis = Compiler.compile_intent(self, self._intent)
+        self.current_vis = Compiler.compile_intent_safe(self, self._intent)
 
     def copy_intent(self):
         # creates a true copy of the dataframe's intent
@@ -635,7 +635,7 @@ class LuxDataFrame(pd.DataFrame):
                 if self._intent != [] and (not hasattr(self, "_compiled") or not self._compiled):
                     from lux.processor.Compiler import Compiler
 
-                    self.current_vis = Compiler.compile_intent(self, self._intent)
+                    self.current_vis = Compiler.compile_intent_safe(self, self._intent)
 
             if lux.config.default_display == "lux":
                 self._toggle_pandas_display = False

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -94,7 +94,6 @@ class PandasExecutor(Executor):
             # TODO: Add some type of cap size on Nrows ?
             vis._vis_data = vis.data.get(list(attributes))
 
-
             if vis.mark == "bar" or vis.mark == "line" or vis.mark == "geographical":
                 PandasExecutor.execute_aggregate(vis, isFiltered=filter_executed)
             elif vis.mark == "histogram":
@@ -217,10 +216,7 @@ class PandasExecutor(Executor):
                             }
                         )
                         vis._vis_data = vis.data.merge(
-                            df,
-                            on=[columns[0], columns[1]],
-                            how="right",
-                            suffixes=["", "_right"],
+                            df, on=[columns[0], columns[1]], how="right", suffixes=["", "_right"],
                         )
                         for col in columns[2:]:
                             vis.data[col] = vis.data[col].fillna(0)  # Triggers __setitem__
@@ -368,10 +364,7 @@ class PandasExecutor(Executor):
                 if color_attr.data_type == "nominal":
                     # Compute mode and count. Mode aggregates each cell by taking the majority vote for the category variable. In cases where there is ties across categories, pick the first item (.iat[0])
                     result = groups.agg(
-                        [
-                            ("count", "count"),
-                            (color_attr.attribute, lambda x: pd.Series.mode(x).iat[0]),
-                        ]
+                        [("count", "count"), (color_attr.attribute, lambda x: pd.Series.mode(x).iat[0]),]
                     ).reset_index()
                 elif color_attr.data_type == "quantitative":
                     # Compute the average of all values in the bin

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -92,7 +92,8 @@ class PandasExecutor(Executor):
                 if clause.attribute != "Record":
                     attributes.add(clause.attribute)
             # TODO: Add some type of cap size on Nrows ?
-            vis._vis_data = vis.data[list(attributes)]
+            vis._vis_data = vis.data.get(list(attributes))
+
 
             if vis.mark == "bar" or vis.mark == "line" or vis.mark == "geographical":
                 PandasExecutor.execute_aggregate(vis, isFiltered=filter_executed)

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -216,7 +216,10 @@ class PandasExecutor(Executor):
                             }
                         )
                         vis._vis_data = vis.data.merge(
-                            df, on=[columns[0], columns[1]], how="right", suffixes=["", "_right"],
+                            df,
+                            on=[columns[0], columns[1]],
+                            how="right",
+                            suffixes=["", "_right"],
                         )
                         for col in columns[2:]:
                             vis.data[col] = vis.data[col].fillna(0)  # Triggers __setitem__
@@ -364,7 +367,10 @@ class PandasExecutor(Executor):
                 if color_attr.data_type == "nominal":
                     # Compute mode and count. Mode aggregates each cell by taking the majority vote for the category variable. In cases where there is ties across categories, pick the first item (.iat[0])
                     result = groups.agg(
-                        [("count", "count"), (color_attr.attribute, lambda x: pd.Series.mode(x).iat[0]),]
+                        [
+                            ("count", "count"),
+                            (color_attr.attribute, lambda x: pd.Series.mode(x).iat[0]),
+                        ]
                     ).reset_index()
                 elif color_attr.data_type == "quantitative":
                     # Compute the average of all values in the bin

--- a/lux/processor/Compiler.py
+++ b/lux/processor/Compiler.py
@@ -308,7 +308,10 @@ class Compiler:
         # ShowMe logic + additional heuristics
         # count_col = Clause( attribute="count()", data_model="measure")
         count_col = Clause(
-            attribute="Record", aggregation="count", data_model="measure", data_type="quantitative",
+            attribute="Record",
+            aggregation="count",
+            data_model="measure",
+            data_type="quantitative",
         )
         auto_channel = {}
         if ndim == 0 and nmsr == 1:
@@ -499,7 +502,9 @@ class Compiler:
                         options = ldf.unique_values[attr]
                         specInd = _inferred_intent.index(clause)
                         _inferred_intent[specInd] = Clause(
-                            attribute=clause.attribute, filter_op="=", value=list(options),
+                            attribute=clause.attribute,
+                            filter_op="=",
+                            value=list(options),
                         )
                     else:
                         options.extend(convert_to_list(clause.value))

--- a/lux/processor/Compiler.py
+++ b/lux/processor/Compiler.py
@@ -96,6 +96,34 @@ class Compiler:
             return vis_collection
 
     @staticmethod
+    def compile_intent_safe(ldf: LuxDataFrame, _inferred_intent: List[Clause]) -> VisList:
+        """
+        Compiles input specifications in the intent of the ldf into a collection of lux.vis objects for visualization.
+        1) Enumerate a collection of visualizations interested by the user to generate a vis list
+        2) Expand underspecified specifications(lux.Clause) for each of the generated visualizations.
+        3) Determine encoding properties for each vis
+        The compiler will return an empty object in case any failure in computation happens for example: Missing intent
+
+        Parameters
+        ----------
+        ldf : lux.core.frame
+                LuxDataFrame with underspecified intent.
+        vis_collection : list[lux.vis.Vis]
+                empty list that will be populated with specified lux.Vis objects.
+
+        Returns
+        -------
+        vis_collection: list[lux.Vis]
+                vis list with compiled lux.Vis objects.
+        """
+        try:
+            return Compiler.compile_intent(ldf, _inferred_intent)
+        except Exception as e:
+            ldf._message.add(f"Failed to compile intent:{e}")
+            return VisList([])
+
+
+    @staticmethod
     def enumerate_collection(_inferred_intent: List[Clause], ldf: LuxDataFrame) -> VisList:
         """
         Given specifications that have been expanded thorught populateOptions,

--- a/lux/processor/Compiler.py
+++ b/lux/processor/Compiler.py
@@ -122,7 +122,6 @@ class Compiler:
             ldf._message.add(f"Failed to compile intent:{e}")
             return VisList([])
 
-
     @staticmethod
     def enumerate_collection(_inferred_intent: List[Clause], ldf: LuxDataFrame) -> VisList:
         """
@@ -309,10 +308,7 @@ class Compiler:
         # ShowMe logic + additional heuristics
         # count_col = Clause( attribute="count()", data_model="measure")
         count_col = Clause(
-            attribute="Record",
-            aggregation="count",
-            data_model="measure",
-            data_type="quantitative",
+            attribute="Record", aggregation="count", data_model="measure", data_type="quantitative",
         )
         auto_channel = {}
         if ndim == 0 and nmsr == 1:
@@ -503,9 +499,7 @@ class Compiler:
                         options = ldf.unique_values[attr]
                         specInd = _inferred_intent.index(clause)
                         _inferred_intent[specInd] = Clause(
-                            attribute=clause.attribute,
-                            filter_op="=",
-                            value=list(options),
+                            attribute=clause.attribute, filter_op="=", value=list(options),
                         )
                     else:
                         options.extend(convert_to_list(clause.value))

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -228,14 +228,12 @@ def test_autoencoding_scatter(global_var):
     check_attribute_on_channel(vis, "MilesPerGal", "y")
     check_attribute_on_channel(vis, "Weight", "x")
     # Duplicate channel specified
-    with pytest.raises(ValueError):
-        # Should throw error because there should not be columns with the same channel specified
-        df.set_intent(
-            [
-                lux.Clause(attribute="MilesPerGal", channel="x"),
-                lux.Clause(attribute="Weight", channel="x"),
-            ]
-        )
+    df.set_intent(
+        [
+            lux.Clause(attribute="MilesPerGal", channel="x"),
+            lux.Clause(attribute="Weight", channel="x"),
+        ]
+    )
     df.clear_intent()
 
 
@@ -282,14 +280,12 @@ def test_autoencoding_line_chart(global_var):
     check_attribute_on_channel(vis, "Year", "y")
     check_attribute_on_channel(vis, "Acceleration", "x")
 
-    with pytest.raises(ValueError):
-        # Should throw error because there should not be columns with the same channel specified
-        df.set_intent(
-            [
-                lux.Clause(attribute="Year", channel="x"),
-                lux.Clause(attribute="Acceleration", channel="x"),
-            ]
-        )
+    df.set_intent(
+        [
+            lux.Clause(attribute="Year", channel="x"),
+            lux.Clause(attribute="Acceleration", channel="x"),
+        ]
+    )
     df.clear_intent()
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -104,24 +104,3 @@ def test_validator_invalid_value(global_var):
         df.intent = ["Region=bob"]
 
     df.clear_intent()
-
-
-def test_validator_invalid_filter(global_var):
-    df = pytest.college_df
-
-    with pytest.raises(KeyError, match="'New England'"):
-        with pytest.warns(
-            UserWarning,
-            match="The input 'New England' looks like a value that belongs to the 'Region' attribute.",
-        ):
-            df.intent = ["New England", "Southeast", "Far West"]
-
-
-def test_validator_invalid_attribute(global_var):
-    df = pytest.college_df
-    with pytest.raises(KeyError, match="'blah'"):
-        with pytest.warns(
-            UserWarning,
-            match="The input attribute 'blah' does not exist in the DataFrame.",
-        ):
-            df.intent = ["blah"]


### PR DESCRIPTION
## Overview

Fixes #276 

## Changes

I have added a new method to compile safely and added fail safe getter to avoid breaking the visualization if the key doesn't exist.

## Example Output

Using missing intent doesn't break the visualization as before

<img width="1117" alt="Screen Shot 2021-04-01 at 8 56 23 PM" src="https://user-images.githubusercontent.com/2458523/113347250-c9e4ef00-932c-11eb-9b2e-c91fc7c0a698.png">

