### PR TITLE
[WIP][Possible bug] Fix always true condition

### DIFF
--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -427,7 +427,7 @@ class PandasExecutor(Executor):
                     if (
                         convertible2int
                         and ldf.cardinality[attr] != len(ldf)
-                        and (len(ldf[attr].convert_dtypes().unique() < 20))
+                        and len(ldf[attr].convert_dtypes().unique()) < 20
                     ):
                         ldf._data_type[attr] = "nominal"
                     else:


### PR DESCRIPTION
## Overview

I noticed that we were using a check that's likely to execute in all cases. I believe the intended behavior is to check that the number of unique vals < 20 to deduce if the column is nominal. 

The existing implementation 
`(len(ldf[attr].convert_dtypes().unique() < 20))` will return always True as long as we don't have an empty array.

I am not sure if that's the intended behavior. In case that's intended, I guess it can be written in a different way

i.e.
`(len(ldf[attr].convert_dtypes().unique() < 20)) == 0`

## Changes

I've changed the implementation to deduce the field type as nominal if the number of unique vals < 20.

## Example Output

<img width="1112" alt="Screen Shot 2021-04-05 at 11 53 52 PM" src="https://user-images.githubusercontent.com/2458523/113636727-f8373700-966a-11eb-8149-0028dc7aaa6e.png">

