### PR TITLE
[WIP] update type inference for string columns

### DIFF
--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -97,7 +97,7 @@ class PandasExecutor(Executor):
             if vis.mark == "bar" or vis.mark == "line" or vis.mark == "geographical":
                 PandasExecutor.execute_aggregate(vis, isFiltered=filter_executed)
             elif vis.mark == "histogram":
-                PandasExecutor.execute_binning(vis)
+                PandasExecutor.execute_binning(ldf, vis)
             elif vis.mark == "scatter":
                 HBIN_START = 5000
                 if lux.config.heatmap and len(ldf) > HBIN_START:
@@ -259,7 +259,7 @@ class PandasExecutor(Executor):
             vis._vis_data = vis._vis_data.drop(columns="index")
 
     @staticmethod
-    def execute_binning(vis: Vis):
+    def execute_binning(ldf, vis: Vis):
         """
         Binning of data points for generating histograms
 
@@ -278,16 +278,24 @@ class PandasExecutor(Executor):
 
         bin_attribute = list(filter(lambda x: x.bin_size != 0, vis._inferred_intent))[0]
         bin_attr = bin_attribute.attribute
-        if not np.isnan(vis.data[bin_attr]).all():
-            # np.histogram breaks if array contain NaN
-            series = vis.data[bin_attr].dropna()
-            # TODO:binning runs for name attribte. Name attribute has datatype quantitative which is wrong.
-            counts, bin_edges = np.histogram(series, bins=bin_attribute.bin_size)
-            # bin_edges of size N+1, so need to compute bin_start as the bin location
-            bin_start = bin_edges[0:-1]
-            # TODO: Should vis.data be a LuxDataFrame or a Pandas DataFrame?
-            binned_result = np.array([bin_start, counts]).T
-            vis._vis_data = pd.DataFrame(binned_result, columns=[bin_attr, "Number of Records"])
+        series = vis.data[bin_attr]
+        # # np.histogram breaks if array contain NaN
+        if (
+            not (pd.api.types.is_float_dtype(series) or pd.api.types.is_integer_dtype(series))
+            or series.hasnans
+        ):
+            if series.hasnans:
+                ldf._message.add_unique(
+                    f"The column <code>{bin_attr}</code> contains missing values, not shown in the displayed histogram.",
+                    priority=100,
+                )
+            series = pd.to_numeric(series.dropna())
+
+        counts, bin_edges = np.histogram(series, bins=bin_attribute.bin_size)
+        # bin_edges of size N+1, so need to compute bin_start as the bin location
+        bin_start = bin_edges[0:-1]
+        binned_result = np.array([bin_start, counts]).T
+        vis._vis_data = pd.DataFrame(binned_result, columns=[bin_attr, "Number of Records"])
 
     @staticmethod
     def execute_filter(vis: Vis):
@@ -445,20 +453,18 @@ class PandasExecutor(Executor):
                         ldf._data_type[attr] = "id"
                 # Eliminate this clause because a single NaN value can cause the dtype to be object
                 elif pd.api.types.is_string_dtype(ldf.dtypes[attr]):
-                    # check first if it's castable to float after removing NaN
+                    # Check first if it's castable to float after removing NaN
                     transformed_col = return_float_or_original(ldf, attr)
-                    if pd.api.types.is_float_dtype(transformed_col):
+                    if pd.api.types.is_float_dtype(transformed_col) or pd.api.types.is_integer_dtype(
+                        transformed_col
+                    ):
                         # int columns gets coerced into floats if contain NaN
-                        convertible2int = pd.api.types.is_integer_dtype(transformed_col.convert_dtypes())
-                        cardinality = len(pd.Index(transformed_col.value_counts()))
-                        if (
-                            convertible2int
-                            and cardinality != len(ldf)
-                            and (len(transformed_col.unique()) < 20)
-                        ):
-                            ldf._data_type[attr] = "nominal"
-                        else:
-                            ldf._data_type[attr] = "quantitative"
+                        ldf._data_type[attr] = "quantitative"
+                        # min max was not computed since object type, so recompute here
+                        ldf._min_max[attr] = (
+                            transformed_col.min(),
+                            transformed_col.max(),
+                        )
                     elif check_if_id_like(ldf, attr):
                         ldf._data_type[attr] = "id"
                     else:

--- a/lux/utils/utils.py
+++ b/lux/utils/utils.py
@@ -125,3 +125,7 @@ def matplotlib_setup(w, h):
     ax.spines["right"].set_color("#dddddd")
     ax.spines["top"].set_color("#dddddd")
     return fig, ax
+
+
+def return_float_or_original(df, attribute):
+    return df[df[attribute].notnull()][attribute].astype("float", errors="ignore")

--- a/lux/utils/utils.py
+++ b/lux/utils/utils.py
@@ -127,5 +127,13 @@ def matplotlib_setup(w, h):
     return fig, ax
 
 
-def return_float_or_original(df, attribute):
-    return df[df[attribute].notnull()][attribute].astype("float", errors="ignore")
+def is_numeric_nan_column(series):
+    if series.dtype == object:
+        if series.hasnans:
+            series = series.dropna()
+        try:
+            return True, series.astype("float")
+        except Exception as e:
+            return False, series
+    else:
+        return False, series

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ Sphinx>=3.0.2
 sphinx-rtd-theme>=0.4.3
 xlrd
 black
+lxml

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -113,3 +113,30 @@ def test_nan_series_occurence():
     ldf = pd.DataFrame(nan_series, columns=["col"])
     ldf._ipython_display_()
     assert ldf.recommendation["Occurrence"][0].mark == "bar"
+
+
+def test_numeric_with_nan():
+    df = pd.read_html(
+        "https://archive.ics.uci.edu/ml/datasets.php?format=&task=&att=&area=&numAtt=&numIns=&type=&sort=nameUp&view=table"
+    )[5]
+    df.columns = df.loc[0]
+    df = df.loc[1:]
+    df["Year"] = pd.to_datetime(df["Year"], format="%Y")
+    assert (
+        df.data_type["# Instances"] == "quantitative"
+    ), "Testing a numeric columns with NaN, check if type can be detected correctly"
+    assert (
+        df.data_type["# Attributes"] == "quantitative"
+    ), "Testing a numeric columns with NaN, check if type can be detected correctly"
+    a = df[["# Instances", "# Attributes"]]
+    a._ipython_display_()
+    assert (
+        len(a.recommendation["Distribution"]) == 2
+    ), "Testing a numeric columns with NaN, check that histograms are displayed"
+    assert "contains missing values" in a._message.to_html(), "Warning message for NaN displayed"
+    a = a.dropna()
+    a._ipython_display_()
+    assert (
+        len(a.recommendation["Distribution"]) == 2
+    ), "Example where dtype might be off after dropna(), check if histograms are still displayed"
+    assert "" in a._message.to_html(), "No warning message for NaN should be displayed"


### PR DESCRIPTION
## Overview

Closes #249

I've noticed that we have a type deduction error in case the field had NaNs as described in the attached issue.
I furthur noticed that we don't check if the string columns can be casted to a float/int type. I've added extra check to see id a string column can be casted to an int/float column and deduce the proper data_type accordingly.

Update (04/10/2021)
* Adding warning message when NaN columns displayed as histograms
* Resolve NaN series causing error in histogram `execute_binning`
* Rewrote `is_numeric_nan_column` to run 2x faster
![image](https://user-images.githubusercontent.com/5554675/114286874-2e265200-9a95-11eb-8e56-85aa5ac8fdbd.png)


## Changes

I've added a logic to 
1. Check if the column can be cast to int/double
2. apply the respective data_type inference.

## Example Output

<img width="1099" alt="Screen Shot 2021-04-05 at 11 51 40 PM" src="https://user-images.githubusercontent.com/2458523/113636919-5a903780-966b-11eb-886c-571f1d132c4c.png">

The result shows that the two columns mentioned in the issue: `# Instances` and `# Attributes` have a correct data_type now 

