### PR TITLE
Scalability: incorporate early pruning optimizations

### DIFF
--- a/lux/_config/config.py
+++ b/lux/_config/config.py
@@ -25,16 +25,23 @@ class Config:
         # flags whether or not an action has been registered or removed and should be re-rendered by frame.py
         self.update_actions: Dict[str, bool] = {}
         self.update_actions["flag"] = False
-        self._sampling_start = 10000
-        self._sampling_cap = 30000
-        self._sampling_flag = True
-        self._heatmap_flag = True
         self._plotting_backend = "vegalite"
         self._topk = 15
         self._sort = "descending"
         self._pandas_fallback = True
         self._interestingness_fallback = True
         self.heatmap_bin_size = 40
+        #####################################
+        #### Optimization Configurations ####
+        #####################################
+        self._sampling_start = 10000
+        self._sampling_cap = 30000
+        self._sampling_flag = True
+        self._heatmap_flag = True
+        self.lazy_maintain = True
+        self.early_pruning = False
+        self.streaming = False
+        self.render_widget = True
 
     @property
     def topk(self):

--- a/lux/_config/config.py
+++ b/lux/_config/config.py
@@ -39,8 +39,10 @@ class Config:
         self._sampling_flag = True
         self._heatmap_flag = True
         self.lazy_maintain = True
-        self.early_pruning = False
+        self.early_pruning = True
         self.early_pruning_sample_cap = 30000
+        # Apply sampling only if the dataset is 150% larger than the sample cap
+        self.early_pruning_sample_start = self.early_pruning_sample_cap * 1.5
         self.streaming = False
         self.render_widget = True
 

--- a/lux/_config/config.py
+++ b/lux/_config/config.py
@@ -34,12 +34,13 @@ class Config:
         #####################################
         #### Optimization Configurations ####
         #####################################
-        self._sampling_start = 10000
-        self._sampling_cap = 30000
+        self._sampling_start = 100000
+        self._sampling_cap = 1000000
         self._sampling_flag = True
         self._heatmap_flag = True
         self.lazy_maintain = True
         self.early_pruning = False
+        self.early_pruning_sample_cap = 30000
         self.streaming = False
         self.render_widget = True
 

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -79,6 +79,7 @@ class LuxDataFrame(pd.DataFrame):
             lux.config.executor = SQLExecutor()
 
         self._sampled = None
+        self._approx_sample = None
         self._toggle_pandas_display = True
         self._message = Message()
         self._pandas_only = False
@@ -120,7 +121,6 @@ class LuxDataFrame(pd.DataFrame):
         Compute dataset metadata and statistics
         """
         if len(self) > 0:
-            print("Actually computing recommendation")
             if lux.config.executor.name != "SQLExecutor":
                 lux.config.executor.compute_stats(self)
             lux.config.executor.compute_dataset_metadata(self)
@@ -134,7 +134,6 @@ class LuxDataFrame(pd.DataFrame):
         is_sql_tbl = lux.config.executor.name == "SQLExecutor"
         if lux.config.SQLconnection != "" and is_sql_tbl:
             from lux.executor.SQLExecutor import SQLExecutor
-
             lux.config.executor = SQLExecutor()
         if lux.config.lazy_maintain:
             # Check that metadata has not yet been computed
@@ -367,6 +366,7 @@ class LuxDataFrame(pd.DataFrame):
         if lux.config.update_actions["flag"] == True:
             self._recs_fresh = False
         show_prev = False  # flag indicating whether rec_df is showing previous df or current self
+        
         if self._prev is not None:
             rec_df = self._prev
             rec_df._message = Message()
@@ -413,7 +413,6 @@ class LuxDataFrame(pd.DataFrame):
         # Check that recs has not yet been computed
         if lazy_but_not_computed or eager:
             is_sql_tbl = lux.config.executor.name == "SQLExecutor"
-            print("Actually computing recommendation")
             rec_infolist = []
             from lux.action.row_group import row_group
             from lux.action.column_group import column_group

--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -134,6 +134,7 @@ class LuxDataFrame(pd.DataFrame):
         is_sql_tbl = lux.config.executor.name == "SQLExecutor"
         if lux.config.SQLconnection != "" and is_sql_tbl:
             from lux.executor.SQLExecutor import SQLExecutor
+
             lux.config.executor = SQLExecutor()
         if lux.config.lazy_maintain:
             # Check that metadata has not yet been computed
@@ -366,7 +367,7 @@ class LuxDataFrame(pd.DataFrame):
         if lux.config.update_actions["flag"] == True:
             self._recs_fresh = False
         show_prev = False  # flag indicating whether rec_df is showing previous df or current self
-        
+
         if self._prev is not None:
             rec_df = self._prev
             rec_df._message = Message()

--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -105,6 +105,25 @@ class LuxSeries(pd.Series):
 
         return lux.core.originalSeries(self, copy=False)
 
+    def unique(self):
+        """
+        Overridden method for pd.Series.unique with cached results.
+        Return unique values of Series object.
+        Uniques are returned in order of appearance. Hash table-based unique,
+        therefore does NOT sort.
+        Returns
+        -------
+        ndarray or ExtensionArray
+            The unique values returned as a NumPy array.
+        See Also
+        --------
+        https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.unique.html
+        """
+        if self.unique_values and self.name in self.unique_values.keys():
+            return np.array(self.unique_values[self.name])
+        else:
+            return super(LuxSeries, self).unique()
+
     def _ipython_display_(self):
         from IPython.display import display
         from IPython.display import clear_output

--- a/lux/executor/Executor.py
+++ b/lux/executor/Executor.py
@@ -11,8 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+from lux.core.frame import LuxDataFrame
 from lux.vis.VisList import VisList
+from lux.vis.Vis import Vis
 from lux.utils import utils
 
 
@@ -28,19 +29,38 @@ class Executor:
         return f"<Executor>"
 
     @staticmethod
-    def execute(vis_collection: VisList, ldf):
+    def execute(vislist: VisList, ldf: LuxDataFrame, approx: bool = False):
+        """
+        Given a VisList, fetch the data required to render the vis.
+        """
         return NotImplemented
 
     @staticmethod
-    def execute_aggregate(vis, ldf):
+    def execute_aggregate(vis: Vis, ldf: LuxDataFrame):
+        """
+        Aggregate data points on an axis for bar or line charts
+        """
         return NotImplemented
 
     @staticmethod
-    def execute_binning(vis, ldf):
+    def execute_binning(ldf: LuxDataFrame, vis: Vis):
+        """
+        Binning of data points for generating histograms
+        """
         return NotImplemented
 
     @staticmethod
-    def execute_filter(vis, ldf):
+    def execute_filter(vis: Vis):
+        """
+        Apply a Vis's filter to vis.data
+        """
+        return NotImplemented
+
+    @staticmethod
+    def execute_2D_binning(vis: Vis):
+        """
+        Apply 2D binning (heatmap) to vis.data
+        """
         return NotImplemented
 
     @staticmethod
@@ -50,10 +70,6 @@ class Executor:
     @staticmethod
     def compute_data_type(self):
         return NotImplemented
-
-    # @staticmethod
-    # def compute_data_model(self):
-    #     return NotImplemented
 
     def mapping(self, rmap):
         group_map = {}

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -293,7 +293,7 @@ class PandasExecutor(Executor):
             vis._vis_data = vis._vis_data.drop(columns="index")
 
     @staticmethod
-    def execute_binning(ldf, vis: Vis):
+    def execute_binning(ldf: LuxDataFrame, vis: Vis):
         """
         Binning of data points for generating histograms
 
@@ -330,7 +330,19 @@ class PandasExecutor(Executor):
         vis._vis_data = pd.DataFrame(binned_result, columns=[bin_attr, "Number of Records"])
 
     @staticmethod
-    def execute_filter(vis: Vis):
+    def execute_filter(vis: Vis) -> bool:
+        """
+        Apply a Vis's filter to vis.data
+
+        Parameters
+        ----------
+        vis : Vis
+
+        Returns
+        -------
+        bool
+            Boolean flag indicating if any filter was applied
+        """
         assert (
             vis.data is not None
         ), "execute_filter assumes input vis.data is populated (if not, populate with LuxDataFrame values)"
@@ -392,7 +404,14 @@ class PandasExecutor(Executor):
         return df
 
     @staticmethod
-    def execute_2D_binning(vis: Vis):
+    def execute_2D_binning(vis: Vis) -> None:
+        """
+        Apply 2D binning (heatmap) to vis.data
+
+        Parameters
+        ----------
+        vis : Vis
+        """
         pd.reset_option("mode.chained_assignment")
         with pd.option_context("mode.chained_assignment", None):
             x_attr = vis.get_attr_by_channel("x")[0].attribute

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -84,8 +84,7 @@ class PandasExecutor(Executor):
         ldf : LuxDataFrame
         """
         if ldf._approx_sample is None:
-            # Apply sampling only if the dataset is 150% larger than the sample cap
-            if len(ldf._sampled) > lux.config.early_pruning_sample_cap * 1.5:
+            if len(ldf._sampled) > lux.config.early_pruning_sample_start:
                 ldf._approx_sample = ldf._sampled.sample(
                     n=lux.config.early_pruning_sample_cap, random_state=1
                 )

--- a/lux/executor/SQLExecutor.py
+++ b/lux/executor/SQLExecutor.py
@@ -48,7 +48,7 @@ class SQLExecutor(Executor):
         )
 
     @staticmethod
-    def execute(view_collection: VisList, tbl: LuxSQLTable):
+    def execute(view_collection: VisList, tbl: LuxSQLTable, approx: bool = False):
         """
         Given a VisList, fetch the data required to render the view
         1) Generate Necessary WHERE clauses

--- a/lux/interestingness/interestingness.py
+++ b/lux/interestingness/interestingness.py
@@ -150,10 +150,9 @@ def interestingness(vis: Vis, ldf: LuxDataFrame) -> int:
                 color_cardinality = ldf.cardinality[color_column]
                 groupby_cardinality = ldf.cardinality[groupby_column]
                 # scale down score based on number of categories
-                chi2_score = chi2_contingency(contingency_tbl)[0] * 0.9 ** (
+                score = chi2_contingency(contingency_tbl)[0] * 0.9 ** (
                     color_cardinality + groupby_cardinality
                 )
-                score = min(0.01, chi2_score)
             except (ValueError, KeyError):
                 # ValueError results if an entire column of the contingency table is 0, can happen if an applied filter results in a category having no counts
                 score = -1
@@ -312,10 +311,7 @@ def unevenness(vis: Vis, ldf: LuxDataFrame, measure_lst: list, dimension_lst: li
     v_flat = pd.Series([1 / C] * len(v))
     if is_datetime(v):
         v = v.astype("int")
-    try:
-        return D * euclidean(v, v_flat)
-    except (ValueError):
-        return 0.01
+    return D * euclidean(v, v_flat)
 
 
 def mutual_information(v_x: list, v_y: list) -> int:

--- a/lux/processor/Compiler.py
+++ b/lux/processor/Compiler.py
@@ -366,6 +366,15 @@ class Compiler:
             for attr in relevant_attributes
             if attr != "Record" and attr in ldf._min_max
         )
+        # Replace scatterplot with heatmap
+        HBIN_START = 5000
+        if vis.mark == "scatter" and lux.config.heatmap and len(ldf) > HBIN_START:
+            vis._postbin = True
+            ldf._message.add_unique(
+                f"Large scatterplots detected: Lux is automatically binning scatterplots to heatmaps.",
+                priority=98,
+            )
+            vis._mark = "heatmap"
         vis._min_max = relevant_min_max
         if auto_channel != {}:
             vis = Compiler.enforce_specified_channel(vis, auto_channel)

--- a/lux/vis/Vis.py
+++ b/lux/vis/Vis.py
@@ -36,6 +36,7 @@ class Vis:
         self.title = title
         self.score = score
         self._all_column = False
+        self.approx = False
         self.refresh_source(self._source)
 
     def __repr__(self):

--- a/lux/vis/VisList.py
+++ b/lux/vis/VisList.py
@@ -318,9 +318,13 @@ class VisList:
                     self._collection = Compiler.compile_intent(ldf, self._inferred_intent)
 
                 # Early pruning determination criteria
-                width_criteria = len(self._collection) > lux.config.topk
-                length_criteria = len(ldf) >= 30000
+                width_criteria = len(self._collection) > (lux.config.topk + 3)
+                length_criteria = len(ldf) > lux.config.early_pruning_sample_start
                 if lux.config.early_pruning and width_criteria and length_criteria:
-                    print("Apply approx to this VisList")
+                    # print("Apply approx to this VisList")
+                    ldf._message.add_unique(
+                        "Large search space detected: Lux is approximating the interestingness of recommended visualizations.",
+                        priority=1,
+                    )
                     approx = True
                 lux.config.executor.execute(self._collection, ldf, approx=approx)

--- a/lux/vis/VisList.py
+++ b/lux/vis/VisList.py
@@ -303,6 +303,7 @@ class VisList:
             self._source = ldf
             self._source.maintain_metadata()
             if len(self._input_lst) > 0:
+                approx = False
                 if self._is_vis_input():
                     compiled_collection = []
                     for vis in self._collection:
@@ -315,4 +316,11 @@ class VisList:
                     self._inferred_intent = Parser.parse(self._intent)
                     Validator.validate_intent(self._inferred_intent, ldf)
                     self._collection = Compiler.compile_intent(ldf, self._inferred_intent)
-                lux.config.executor.execute(self._collection, ldf)
+                
+                # Early pruning determination criteria
+                width_criteria = len(self._collection) > lux.config.topk
+                length_criteria = len(ldf) >= 30000
+                if lux.config.early_pruning and width_criteria and length_criteria:
+                    print("Apply approx to this VisList")
+                    approx = True
+                lux.config.executor.execute(self._collection, ldf, approx=approx)

--- a/lux/vis/VisList.py
+++ b/lux/vis/VisList.py
@@ -316,7 +316,7 @@ class VisList:
                     self._inferred_intent = Parser.parse(self._intent)
                     Validator.validate_intent(self._inferred_intent, ldf)
                     self._collection = Compiler.compile_intent(ldf, self._inferred_intent)
-                
+
                 # Early pruning determination criteria
                 width_criteria = len(self._collection) > lux.config.topk
                 length_criteria = len(ldf) >= 30000

--- a/lux/vislib/altair/AltairRenderer.py
+++ b/lux/vislib/altair/AltairRenderer.py
@@ -55,6 +55,7 @@ class AltairRenderer:
                 vis._mark = "heatmap"
                 lux.config.executor.execute_2D_binning(vis)
             else:
+                # Exactly recompute the selected vis (e.g., top k) to display
                 lux.config.executor.execute([vis], vis._original_df, approx=False)
         # If a column has a Period dtype, or contains Period objects, convert it back to Datetime
         if vis.data is not None:

--- a/lux/vislib/altair/AltairRenderer.py
+++ b/lux/vislib/altair/AltairRenderer.py
@@ -50,10 +50,12 @@ class AltairRenderer:
                 Output Altair Chart Object
         """
         # Lazy Evaluation for 2D Binning
-        if vis.mark == "scatter" and vis._postbin:
-            if lux.config.executor.name == "PandasExecutor":
+        if vis.approx:
+            if vis.mark == "scatter" and vis._postbin:
                 vis._mark = "heatmap"
                 lux.config.executor.execute_2D_binning(vis)
+            else:
+                lux.config.executor.execute([vis], vis._original_df, approx=False)
         # If a column has a Period dtype, or contains Period objects, convert it back to Datetime
         if vis.data is not None:
             for attr in list(vis.data.columns):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ sphinx-automodapi>=0.13
 Sphinx>=3.0.2
 sphinx-rtd-theme>=0.4.3
 xlrd
-black
+black>=20.8b1
 # Install to use SQLExecutor
 psycopg2>=2.8.5
 psycopg2-binary>=2.8.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ sphinx-automodapi>=0.13
 Sphinx>=3.0.2
 sphinx-rtd-theme>=0.4.3
 xlrd
-black>=20.8b1
+black==20.8b1
 # Install to use SQLExecutor
 psycopg2>=2.8.5
 psycopg2-binary>=2.8.5

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -202,6 +202,7 @@ def test_year_filter_value(global_var):
 
 
 def test_similarity(global_var):
+    lux.config.early_pruning = False
     df = pytest.car_df
     df["Year"] = pd.to_datetime(df["Year"], format="%Y")
     df.set_intent(
@@ -229,6 +230,7 @@ def test_similarity(global_var):
     )[0]
     assert japan_vis.score > europe_vis.score
     df.clear_intent()
+    lux.config.early_pruning = True
 
 
 def test_similarity2():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,6 +221,9 @@ def test_set_default_plotting_style():
 
 
 def test_sampling_flag_config():
+    lux.config.heatmap = False
+    lux.config.sampling = True
+    lux.config.early_pruning = False
     df = pd.read_csv("https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/airbnb_nyc.csv")
     df._ipython_display_()
     assert df.recommendation["Correlation"][0].data.shape[0] == 30000
@@ -229,6 +232,8 @@ def test_sampling_flag_config():
     df._ipython_display_()
     assert df.recommendation["Correlation"][0].data.shape[0] == 48895
     lux.config.sampling = True
+    lux.config.heatmap = True
+    lux.config.early_pruning = True
 
 
 def test_sampling_parameters_config():
@@ -245,6 +250,7 @@ def test_sampling_parameters_config():
 
 
 def test_heatmap_flag_config():
+    lux.config.heatmap = True
     df = pd.read_csv("https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/airbnb_nyc.csv")
     df._ipython_display_()
     assert df.recommendation["Correlation"][0]._postbin

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,13 +224,12 @@ def test_sampling_flag_config():
     lux.config.heatmap = False
     lux.config.sampling = True
     lux.config.early_pruning = False
-    df = pd.read_csv("https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/airbnb_nyc.csv")
-    df._ipython_display_()
-    assert df.recommendation["Correlation"][0].data.shape[0] == 30000
-    lux.config.sampling = False
-    df = df.copy()
-    df._ipython_display_()
-    assert df.recommendation["Correlation"][0].data.shape[0] == 48895
+    import numpy as np
+
+    N = int(1.1 * lux.config.sampling_cap)
+    df = pd.DataFrame({"col1": np.random.rand(N), "col2": np.random.rand(N)})
+    df.maintain_recs()
+    assert len(df.recommendation["Correlation"][0].data) == lux.config.sampling_cap
     lux.config.sampling = True
     lux.config.heatmap = True
     lux.config.early_pruning = True

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -20,23 +20,42 @@ import time
 
 # To run the script and see the printed result, run:
 # python -m pytest -s tests/test_performance.py
-def test_q1_performance_census(global_var):
+def test_lazy_maintain_performance_census(global_var):
+    lux.config.lazy_maintain = True
     df = pd.read_csv("https://github.com/lux-org/lux-datasets/blob/master/data/census.csv?raw=true")
     tic = time.perf_counter()
-    df._ipython_display_()
+    df.maintain_recs()
     toc = time.perf_counter()
     delta = toc - tic
-    df._ipython_display_()
+    df.maintain_recs()
     toc2 = time.perf_counter()
     delta2 = toc2 - toc
     print(f"1st display Performance: {delta:0.4f} seconds")
     print(f"2nd display Performance: {delta2:0.4f} seconds")
     assert (
-        delta < 4.5
+        delta < 4
     ), "The recommendations on Census dataset took a total of {delta:0.4f} seconds, longer than expected."
     assert (
-        delta2 < 0.15 < delta
+        delta2 < 0.1 < delta
     ), "Subsequent display of recommendations on Census dataset took a total of {delta2:0.4f} seconds, longer than expected."
+
+    lux.config.lazy_maintain = False
+    tic = time.perf_counter()
+    df.maintain_recs()
+    toc = time.perf_counter()
+    delta = toc - tic
+    df.maintain_recs()
+    toc2 = time.perf_counter()
+    delta2 = toc2 - toc
+    print(f"1st display Performance: {delta:0.4f} seconds")
+    print(f"2nd display Performance: {delta2:0.4f} seconds")
+
+    assert (
+        delta > 3
+    ), "The recompute of recommendations on Census dataset took a total of {delta:0.4f} seconds, shorter than expected."
+    assert (
+        delta2 > 3
+    ), "Subsequent recompute of recommendations on Census dataset took a total of {delta2:0.4f} seconds, shorter than expected."
 
     assert df.data_type == {
         "age": "quantitative",


### PR DESCRIPTION
## Overview

Incorporating early pruning optimizations described in [our recent paper](http://dorisjunglinlee.com/files/lux-vldb-tr.pdf) to speed up cases where the visualization search space is large (e.g., VisList contains more than top K visualizations and the dataframe has a large number of rows).

## Changes

- Adding in `execute_approx_sample` for approximating samples for early pruning
- Apply early pruning based on empirically-tested width and length criteria
- Added tests and warning messages when early pruning conditions are met

Others: 
- Increasing the sampling start and cap for overall sampling
- Adding config flag to turn lazy maintenance on/off
- Added cached method for `df.unique()`

## Example Output

Here are some results from preliminary experiments on the 1M Airbnb dataset. We duplicate a single visualization N number of times and measuring the performance. The time is the sum of the time it takes to go through the search space and the time that it takes to recompute the top K visualization upon display of the VisList. The significant speedup in the former time supersedes extra time it takes for recompute, around 17, typically no more than a few more than 15 (which k=15).
<div>
    <img src="https://user-images.githubusercontent.com/5554675/116308502-23c8bf80-a7da-11eb-8a35-b21deef0f8ff.png" width=350></img>
    <img src="https://user-images.githubusercontent.com/5554675/116308531-2deabe00-a7da-11eb-85d9-f1e43b212be9.png" width=350>
    </img>
</div>

Zooming out, the speedup can be significant when searching through over 100+ vis: 
    <img src="https://user-images.githubusercontent.com/5554675/116308603-465ad880-a7da-11eb-82e4-74aaebd514ab.png" width=350></img>


