### PR TITLE
Bugfix for all column and temporal action

### DIFF
--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -355,7 +355,7 @@ class LuxDataFrame(pd.DataFrame):
             rec_infolist.append(recommendations)
 
     def show_all_column_vis(self):
-        if self.intent == [] or self.intent is None:
+        if len(self.columns) > 1 and len(self.columns) < 4 and self.intent == [] or self.intent is None:
             vis = Vis(list(self.columns), self)
             if vis.mark != "":
                 vis._all_column = True

--- a/lux/processor/Compiler.py
+++ b/lux/processor/Compiler.py
@@ -273,7 +273,15 @@ class Compiler:
             if measure.aggregation == "":
                 measure.set_aggregation("mean")
             if dim_type == "temporal" or dim_type == "oridinal":
-                return "line", {"x": dimension, "y": measure}
+                if isinstance(dimension.attribute, pd.Timestamp):
+                    # If timestamp, use the _repr_ (e.g., TimeStamp('2020-04-05 00.000')--> '2020-04-05')
+                    attr = str(dimension.attribute._date_repr)
+                else:
+                    attr = dimension.attribute
+                if ldf.cardinality[attr] == 1:
+                    return "bar", {"x": measure, "y": dimension}
+                else:
+                    return "line", {"x": dimension, "y": measure}
             else:  # unordered categorical
                 # if cardinality large than 5 then sort bars
                 if ldf.cardinality[dimension.attribute] > 5:

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -51,6 +51,13 @@ class BarChart(AltairChart):
             x_attr.attribute = x_attr.attribute.replace(".", "")
         if isinstance(y_attr.attribute, str):
             y_attr.attribute = y_attr.attribute.replace(".", "")
+        # To get datetime to display correctly on bar charts
+        if x_attr.data_type == "temporal":
+            x_attr.data_type = "nominal"
+            self.code += "from pandas import Timestamp\n"
+        if y_attr.data_type == "temporal":
+            y_attr.data_type = "nominal"
+            self.code += "from pandas import Timestamp\n"
 
         if x_attr.data_model == "measure":
             agg_title = get_agg_title(x_attr)

--- a/lux/vislib/altair/LineChart.py
+++ b/lux/vislib/altair/LineChart.py
@@ -61,8 +61,7 @@ class LineChart(AltairChart):
         # Remove NaNs only for Line Charts (offsets axis range)
         self.data = self.data.dropna(subset=[x_attr.attribute, y_attr.attribute])
         self.code += "import altair as alt\n"
-        self.code += "import pandas._libs.tslibs.timestamps\n"
-        self.code += "from pandas._libs.tslibs.timestamps import Timestamp\n"
+        self.code += "from pandas import Timestamp\n"
         self.code += f"visData = pd.DataFrame({str(self.data.to_dict())})\n"
 
         if y_attr.data_model == "measure":

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -75,6 +75,17 @@ def test_series_recommendation():
     assert len(df.recommendation["Distribution"]) > 0, "Recommendation property empty for LuxSeries"
 
 
+def test_series_multivis_recommendation():
+    covid = pd.read_csv(
+        "https://github.com/lux-org/lux-datasets/blob/master/data/covid-stringency.csv?raw=True"
+    )
+    covid = covid.rename(columns={"stringency_index": "stringency"})
+    covid["Day"] = pd.to_datetime(covid["Day"], format="%Y-%m-%d")
+    series = covid["Day"]
+    assert len(series.recommendation["Temporal"]) == 4, "Display 4 temporal vis based on `Day`"
+    assert hasattr(series, "current_vis") == False
+
+
 def test_unnamed_column():
     lux.config.plotting_backend = "matplotlib"
     df = pd.read_csv("https://raw.githubusercontent.com/lux-org/lux-datasets/master/data/employee.csv")


### PR DESCRIPTION
Several bugfixes for the new COVID HPI demo:

* For all column vis, display only if more than one column (i.e., not series), since visualization is a duplicate of series vis

  * Before: 
![image](https://user-images.githubusercontent.com/5554675/116953318-811fad80-acbf-11eb-8fa3-42fd89b228af.png)

  * After:
![image](https://user-images.githubusercontent.com/5554675/116953354-94327d80-acbf-11eb-9a63-cba5242466ea.png)

* For temporal, when there is only a single data point for a date, display a single bar instead of a line chart, since it is not possible to display a line chart with only a single data point. 

  * Before: 
<img src="https://user-images.githubusercontent.com/5554675/116953247-5d5c6780-acbf-11eb-930a-ad8e7237343b.png" width="50%"></img>

  * After:
<img src="https://user-images.githubusercontent.com/5554675/116953118-0787bf80-acbf-11eb-9c77-a67217f74c67.png" width="70%"></img>
