### PR TITLE
Bugfix LuxSeriesGroupBy apply

### DIFF
--- a/lux/core/frame.py
+++ b/lux/core/frame.py
@@ -851,12 +851,6 @@ class LuxDataFrame(pd.DataFrame):
         ret_val._history.append_event("tail", n=5)
         return ret_val
 
-    def describe(self, *args, **kwargs):
-        ret_val = super(LuxDataFrame, self).describe(*args, **kwargs)
-        ret_val._pandas_only = True
-        ret_val._history.append_event("describe", *args, **kwargs)
-        return ret_val
-
     def groupby(self, *args, **kwargs):
         history_flag = False
         if "history" not in kwargs or ("history" in kwargs and kwargs["history"]):

--- a/lux/core/groupby.py
+++ b/lux/core/groupby.py
@@ -67,13 +67,6 @@ class LuxGroupBy(pd.core.groupby.groupby.GroupBy):
         ret_val.pre_aggregated = False  # Returned LuxDataFrame isn't pre_aggregated
         return ret_val
 
-    def apply(self, *args, **kwargs):
-        ret_val = super(LuxDataFrameGroupBy, self).apply(*args, **kwargs)
-        for attr in self._metadata:
-            ret_val.__dict__[attr] = getattr(self, attr, None)
-        ret_val.pre_aggregated = False  # Returned LuxDataFrame isn't pre_aggregated
-        return ret_val
-
     def size(self, *args, **kwargs):
         ret_val = super(LuxGroupBy, self).size(*args, **kwargs)
         for attr in self._metadata:

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -34,13 +34,17 @@ def test_head_tail(global_var):
         in df._message.to_html()
     )
 
-
 def test_describe(global_var):
     df = pytest.college_df
     summary = df.describe()
     summary._ipython_display_()
     assert len(summary.columns) == 10
 
+def test_groupby_describe(global_var):
+    df = pytest.college_df
+    result = df.groupby("FundingModel")["AdmissionRate"].describe()
+    result._ipython_display_()
+    assert result.shape ==(3,8)
 
 def test_convert_dtype(global_var):
     df = pytest.college_df

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -34,17 +34,20 @@ def test_head_tail(global_var):
         in df._message.to_html()
     )
 
+
 def test_describe(global_var):
     df = pytest.college_df
     summary = df.describe()
     summary._ipython_display_()
     assert len(summary.columns) == 10
 
+
 def test_groupby_describe(global_var):
     df = pytest.college_df
     result = df.groupby("FundingModel")["AdmissionRate"].describe()
     result._ipython_display_()
-    assert result.shape ==(3,8)
+    assert result.shape == (3, 8)
+
 
 def test_convert_dtype(global_var):
     df = pytest.college_df


### PR DESCRIPTION
## Overview

This PR fixes the issue in #382 for `df.groupby("some_column")["some_other_column"].describe()`.
It also deactivates the disabled Lux display for `df.describe` to ensure consistency with other Pandas APIs.
