### PR TITLE
Additional configuration options for number of bars and axis labels

### DIFF
--- a/doc/source/reference/config.rst
+++ b/doc/source/reference/config.rst
@@ -254,3 +254,19 @@ In Lux, large scatterplots are displayed as heatmaps that are 40x40 by default. 
     lux.config.heatmap_bin_size = 100
 
 This generates heatmap visualizations that are binned into a 100x100 grid. 
+
+
+
+Change the maximum number of bars displayed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In Lux, we limit the maximum number of bars displayed in a bar chart to 10 bars to avoid cluttering. 
+If you want Lux to display more bars in each chart, we can set the :code:`number_of_bars` to increase the maximum number of bars displayed. 
+
+.. code-block:: python
+
+    lux.config.number_of_bars = 20
+
+.. image:: https://github.com/lux-org/lux-resources/blob/master/doc_img/config_bars.png?raw=true
+  :width: 400
+  :align: left

--- a/doc/source/reference/gen/lux._config.config.Config.rst
+++ b/doc/source/reference/gen/lux._config.config.Config.rst
@@ -30,6 +30,8 @@
       ~Config.default_display
       ~Config.heatmap
       ~Config.interestingness_fallback
+      ~Config.label_len
+      ~Config.number_of_bars
       ~Config.pandas_fallback
       ~Config.plotting_backend
       ~Config.plotting_scale

--- a/lux/_config/config.py
+++ b/lux/_config/config.py
@@ -28,6 +28,8 @@ class Config:
         self._plotting_backend = "vegalite"
         self._plotting_scale = 1
         self._topk = 15
+        self._number_of_bars = 10  # max no of bars displayed (rest shown as "+ k more")
+        self._label_len = 25  # max length of x and y axis labels
         self._sort = "descending"
         self._pandas_fallback = True
         self._interestingness_fallback = True
@@ -46,6 +48,46 @@ class Config:
         self.early_pruning_sample_start = self.early_pruning_sample_cap * 1.5
         self.streaming = False
         self.render_widget = True
+
+    @property
+    def number_of_bars(self):
+        return self._number_of_bars
+
+    @number_of_bars.setter
+    def number_of_bars(self, k: int) -> None:
+        """
+        Parameters
+        ----------
+        k : int
+            Number of bars in output bar charts; rest are not displayed
+        """
+        if type(k) == int:
+            self._number_of_bars = k
+        else:
+            warnings.warn(
+                "The number of bars must be an integer.",
+                stacklevel=2,
+            )
+
+    @property
+    def label_len(self):
+        return self._label_len
+
+    @label_len.setter
+    def label_len(self, l: int) -> None:
+        """
+        Parameters
+        ----------
+        l : int
+            Maximum length of string axis labels
+        """
+        if type(l) == int:
+            self._label_len = l
+        else:
+            warnings.warn(
+                "The maximum length must be an integer.",
+                stacklevel=2,
+            )
 
     @property
     def topk(self):

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -15,9 +15,10 @@
 from lux.vislib.altair.AltairChart import AltairChart
 import altair as alt
 import lux
+import math
 
 alt.data_transformers.disable_max_rows()
-from lux.utils.utils import get_agg_title
+from lux.utils.utils import check_if_id_like, get_agg_title
 
 
 class BarChart(AltairChart):
@@ -41,17 +42,22 @@ class BarChart(AltairChart):
         x_attr = self.vis.get_attr_by_channel("x")[0]
         y_attr = self.vis.get_attr_by_channel("y")[0]
 
+        # Deal with overlong string axes labels
         x_attr_abv = str(x_attr.attribute)
         y_attr_abv = str(y_attr.attribute)
+        label_len = lux.config.label_len
+        prefix_len = math.ceil(3.0 * label_len / 5.0)
+        suffix_len = label_len - prefix_len
+        if len(x_attr_abv) > label_len:
+            x_attr_abv = x_attr.attribute[:prefix_len] + "..." + x_attr.attribute[-suffix_len:]
+        if len(y_attr_abv) > label_len:
+            y_attr_abv = y_attr.attribute[:prefix_len] + "..." + y_attr.attribute[-suffix_len:]
 
-        if len(x_attr_abv) > 25:
-            x_attr_abv = x_attr.attribute[:15] + "..." + x_attr.attribute[-10:]
-        if len(y_attr_abv) > 25:
-            y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
         if isinstance(x_attr.attribute, str):
             x_attr.attribute = x_attr.attribute.replace(".", "")
         if isinstance(y_attr.attribute, str):
             y_attr.attribute = y_attr.attribute.replace(".", "")
+
         # To get datetime to display correctly on bar charts
         if x_attr.data_type == "temporal":
             x_attr.data_type = "nominal"
@@ -99,7 +105,8 @@ class BarChart(AltairChart):
             if x_attr.sort == "ascending":
                 x_attr_field.sort = "-y"
                 x_attr_field_code = f"alt.X('{x_attr.attribute}', type= '{x_attr.data_type}', axis=alt.Axis(labelOverlap=True, title='{x_attr_abv}'),sort='-y')"
-        k = 10
+
+        k = lux.config.number_of_bars
         self._topkcode = ""
         n_bars = len(self.data.iloc[:, 0].unique())
         plotting_scale = lux.config.plotting_scale

--- a/lux/vislib/altair/BarChart.py
+++ b/lux/vislib/altair/BarChart.py
@@ -18,7 +18,7 @@ import lux
 import math
 
 alt.data_transformers.disable_max_rows()
-from lux.utils.utils import check_if_id_like, get_agg_title
+from lux.utils.utils import get_agg_title
 
 
 class BarChart(AltairChart):

--- a/lux/vislib/matplotlib/BarChart.py
+++ b/lux/vislib/matplotlib/BarChart.py
@@ -16,11 +16,13 @@ from lux.vislib.matplotlib.MatplotlibChart import MatplotlibChart
 from lux.utils.utils import get_agg_title
 import pandas as pd
 import numpy as np
+import math
 import matplotlib.pyplot as plt
 from lux.utils.utils import matplotlib_setup
 from matplotlib.cm import ScalarMappable
 from lux.utils.date_utils import compute_date_granularity
 from matplotlib.ticker import MaxNLocator
+import lux
 
 
 class BarChart(MatplotlibChart):
@@ -44,13 +46,16 @@ class BarChart(MatplotlibChart):
         x_attr = self.vis.get_attr_by_channel("x")[0]
         y_attr = self.vis.get_attr_by_channel("y")[0]
 
-        x_attr_abv = x_attr.attribute
-        y_attr_abv = y_attr.attribute
-
-        if len(x_attr.attribute) > 25:
-            x_attr_abv = x_attr.attribute[:15] + "..." + x_attr.attribute[-10:]
-        if len(y_attr.attribute) > 25:
-            y_attr_abv = y_attr.attribute[:15] + "..." + y_attr.attribute[-10:]
+        # Deal with overlong string axes labels
+        x_attr_abv = str(x_attr.attribute)
+        y_attr_abv = str(y_attr.attribute)
+        label_len = lux.config.label_len
+        prefix_len = prefix_len = math.ceil(3.0 * label_len / 5.0)
+        suffix_len = label_len - prefix_len
+        if len(x_attr_abv) > label_len:
+            x_attr_abv = x_attr.attribute[:prefix_len] + "..." + x_attr.attribute[-suffix_len:]
+        if len(y_attr_abv) > label_len:
+            y_attr_abv = y_attr.attribute[:prefix_len] + "..." + y_attr.attribute[-suffix_len:]
 
         if x_attr.data_model == "measure":
             agg_title = get_agg_title(x_attr)
@@ -61,7 +66,7 @@ class BarChart(MatplotlibChart):
             measure_attr = y_attr.attribute
             bar_attr = x_attr.attribute
 
-        k = 10
+        k = lux.config.number_of_bars
         n_bars = len(self.data.iloc[:, 0].unique())
         if n_bars > k:  # Truncating to only top k
             remaining_bars = n_bars - k


### PR DESCRIPTION
## Overview

Resolves issue #408. In addition adds the ability to set display axis label lengths.
 
## Changes

Changes made to altair and matplotlib bar chart specifications, as well as configuration. 

## Example Output

Should allow users to set number of bars in bar charts, and change default max axis label lengths. 