### PR TITLE
FIX-#431: implement sampling threshold and edit tests and docs

### DIFF
--- a/doc/source/reference/config.rst
+++ b/doc/source/reference/config.rst
@@ -144,16 +144,15 @@ Lux currently only support Vega-Lite and matplotlib, and we plan to add support 
 Change the sampling parameters 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To speed up the visualization processing, by default, Lux performs random sampling on datasets with more than 10000 rows. For datasets over 30000 rows, Lux will randomly sample 30000 rows from the dataset.
+To speed up the visualization processing, by default, Lux performs random sampling on datasets with more than 100000 rows. Specifically, for datasets over 100000 rows, Lux will randomly sample 100000 rows from the dataset.
 
-If we want to change these parameters, we can set the `sampling_start` and `sampling_cap` via `lux.config` to change the default form of output. The `sampling_start` is by default set to 10000 and the `sampling_cap` is by default set to 30000. In the following block, we increase these sampling bounds.
+If we want to change these parameters, we can set the `sampling_thresh` via `lux.config` to change the default form of output. The `sampling_thresh` is by default set to 100000. In the following block, we increase this sampling threshold.
 
 .. code-block:: python
 
-    lux.config.sampling_start = 20000
-    lux.config.sampling_cap = 40000
+    lux.config.sampling_thresh = 500000
 
-If we want Lux to use the full dataset in the visualization, we can also disable sampling altogether (but note that this may result in long processing times). Below is an example if disabling the sampling:
+If we want Lux to use the full dataset in the visualization, we can also disable sampling altogether (but note that this may result in long processing times). Below is an example of disabling the sampling:
 
 .. code-block:: python
 

--- a/lux/_config/config.py
+++ b/lux/_config/config.py
@@ -44,8 +44,7 @@ class Config:
         #####################################
         #### Optimization Configurations ####
         #####################################
-        self._sampling_start = 100000
-        self._sampling_cap = 1000000
+        self._sampling_thresh = 100000
         self._sampling_flag = True
         self._heatmap_flag = True
         self._heatmap_start = 5000
@@ -186,34 +185,7 @@ class Config:
             )
 
     @property
-    def sampling_cap(self):
-        """
-        Parameters
-        ----------
-        sample_number : int
-            Cap on the number of rows to sample. Must be larger than _sampling_start
-        """
-        return self._sampling_cap
-
-    @sampling_cap.setter
-    def sampling_cap(self, sample_number: int) -> None:
-        """
-        Parameters
-        ----------
-        sample_number : int
-            Cap on the number of rows to sample. Must be larger than _sampling_start
-        """
-        if type(sample_number) == int:
-            assert sample_number >= self._sampling_start
-            self._sampling_cap = sample_number
-        else:
-            warnings.warn(
-                "The cap on the number samples must be an integer.",
-                stacklevel=2,
-            )
-
-    @property
-    def sampling_start(self):
+    def sampling_thresh(self):
         """
         Parameters
         ----------
@@ -221,20 +193,19 @@ class Config:
             Number of rows required to begin sampling. Must be smaller or equal to _sampling_cap
 
         """
-        return self._sampling_start
+        return self._sampling_thresh
 
-    @sampling_start.setter
-    def sampling_start(self, sample_number: int) -> None:
+    @sampling_thresh.setter
+    def sampling_thresh(self, sample_number: int) -> None:
         """
         Parameters
         ----------
         sample_number : int
-            Number of rows required to begin sampling. Must be smaller or equal to _sampling_cap
+            Number of rows required to begin sampling.
 
         """
         if type(sample_number) == int:
-            assert sample_number <= self._sampling_cap
-            self._sampling_start = sample_number
+            self._sampling_thresh = sample_number
         else:
             warnings.warn(
                 "The sampling starting point must be an integer.",

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -53,22 +53,13 @@ class PandasExecutor(Executor):
         ldf : LuxDataFrame
         """
         SAMPLE_FLAG = lux.config.sampling
-        SAMPLE_START = lux.config.sampling_start
-        SAMPLE_CAP = lux.config.sampling_cap
-        SAMPLE_FRAC = 0.75
+        SAMPLE_THRESH = lux.config.sampling_thresh
 
-        if SAMPLE_FLAG and len(ldf) > SAMPLE_CAP:
+        if SAMPLE_FLAG and len(ldf) > SAMPLE_THRESH:
             if ldf._sampled is None:  # memoize unfiltered sample df
-                ldf._sampled = ldf.sample(n=SAMPLE_CAP, random_state=1)
+                ldf._sampled = ldf.sample(n=SAMPLE_THRESH, random_state=1)
             ldf._message.add_unique(
-                f"Large dataframe detected: Lux is only visualizing a sample capped at {SAMPLE_CAP} rows.",
-                priority=99,
-            )
-        elif SAMPLE_FLAG and len(ldf) > SAMPLE_START:
-            if ldf._sampled is None:  # memoize unfiltered sample df
-                ldf._sampled = ldf.sample(frac=SAMPLE_FRAC, random_state=1)
-            ldf._message.add_unique(
-                f"Large dataframe detected: Lux is visualizing a sample of {SAMPLE_FRAC}% of the dataframe ({len(ldf._sampled)} rows).",
+                f"Large dataframe detected: Lux is only visualizing a sample of {SAMPLE_THRESH} rows.",
                 priority=99,
             )
         else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -226,10 +226,10 @@ def test_sampling_flag_config():
     lux.config.early_pruning = False
     import numpy as np
 
-    N = int(1.1 * lux.config.sampling_cap)
+    N = int(1.1 * lux.config.sampling_thresh)
     df = pd.DataFrame({"col1": np.random.rand(N), "col2": np.random.rand(N)})
     df.maintain_recs()
-    assert len(df.recommendation["Correlation"][0].data) == lux.config.sampling_cap
+    assert len(df.recommendation["Correlation"][0].data) == lux.config.sampling_thresh
     lux.config.sampling = True
     lux.config.heatmap = True
     lux.config.early_pruning = True
@@ -239,13 +239,12 @@ def test_sampling_parameters_config():
     df = pd.read_csv("lux/data/car.csv")
     df._ipython_display_()
     assert df.recommendation["Correlation"][0].data.shape[0] == 392
-    lux.config.sampling_start = 50
-    lux.config.sampling_cap = 100
+    old_sampling_thresh = lux.config.sampling_thresh
+    lux.config.sampling_thresh = 100
     df = pd.read_csv("lux/data/car.csv")
     df._ipython_display_()
     assert df.recommendation["Correlation"][0].data.shape[0] == 100
-    lux.config.sampling_cap = 30000
-    lux.config.sampling_start = 10000
+    lux.config.sampling_thresh = old_sampling_thresh
 
 
 def test_heatmap_flag_config():

--- a/tests/test_maintainence.py
+++ b/tests/test_maintainence.py
@@ -85,6 +85,8 @@ def test_recs_inplace_operation(global_var):
 
 
 def test_intent_cleared_after_vis_data():
+    old_sampling_thresh = lux.config.sampling_thresh
+    lux.config.sampling_thresh = 10000
     df = pd.read_csv(
         "https://github.com/lux-org/lux-datasets/blob/master/data/real_estate_tutorial.csv?raw=true"
     )
@@ -96,9 +98,10 @@ def test_intent_cleared_after_vis_data():
         lux.Clause("City=Crofton"),
     ]
     df._ipython_display_()
-
     vis = df.recommendation["Similarity"][0]
     vis.data._ipython_display_()
     all_column_vis = vis.data.current_vis[0]
     assert all_column_vis.get_attr_by_channel("x")[0].attribute == "Year"
+    print(all_column_vis.get_attr_by_channel("y"))
     assert all_column_vis.get_attr_by_channel("y")[0].attribute == "PctForeclosured"
+    lux.config.sampling_thresh = old_sampling_thresh


### PR DESCRIPTION
Signed-off-by: Kunal Agarwal <kagarwal2@berkeley.edu>

## Overview

I removed the sampling_cap and sampling_start from the config and `execute_sampling`. Instead, I added a `sampling_thresh`, which is a threshold for which we'd begin sampling. This threshold forces any data larger than the threshold to sample the data such that the sample is equal to the size specified by the threshold. More information can be found in the documentation that was edited as part of this PR.

## Changes

I edited `config` and `execute_sampling` to implement this fix. I also edited the tests to account for the removal of the old configs and the addition of the new one. I finally edited the documentation to reflect these changes.

## Example Output

The issue described in #431 should be fixed now.
