### PR TITLE
Adds pre-commit hooks

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,6 +29,13 @@ jobs:
       - run: git remote add upstream https://github.com/lux-org/lux
       - run: git fetch upstream
       - run: npx commitlint --from upstream/master --to HEAD --verbose
+  pre-commit:
+    name: Check pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3
   build:
 
     runs-on: ubuntu-latest
@@ -77,9 +84,6 @@ jobs:
         python lux/data/upload_car_data.py
         python lux/data/upload_aug_test_data.py
         python lux/data/upload_airbnb_nyc_data.py
-    - name: Lint check with black
-      run: |
-        black --target-version py37 --line-length 105 --check .
     - name: Test with Pytest and Code Coverage Report
       run: |
         pytest --cov-report term --cov=lux tests/ tests_sql/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,21 @@ lux/
 ```
 
 # Code Formatting
-In order to keep our codebase clean and readible, we are using PEP8 guidelines. To help us maintain and check code style, we are using [black](https://github.com/psf/black). Simply run `black .` before commiting. Without running black,  the checks on the continuous integration tests can fail. `black` should be installed for you as part of [requirements-dev](https://github.com/lux-org/lux/blob/master/requirements-dev.txt). 
+In order to keep our codebase clean and readible, we are using PEP8 guidelines. To help us maintain and check code style currently we use the following `pre-commit` hooks to automatically format the code on every commit and enforce its formatting on CI:
+
+* [black](https://github.com/psf/black)
+
+Precommit hooks are installed for you as part of [requirements-dev.txt](https://github.com/lux-org/lux/blob/master/requirements-dev.txt). To ensure precommit hooks run on every commit, run the install command:
+
+```bash
+pre-commit install
+```
+
+To manually run precommit hooks use:
+
+```bash
+pre-commit run --all-files
+``` 
 
 # Running the Test Suite
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 105
-exclude = 'Executor\.py$'
+force-exclude = 'Executor\.py$'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ black==20.8b1
 psycopg2>=2.8.5
 psycopg2-binary>=2.8.5
 lxml
+pre-commit~=2.15.0


### PR DESCRIPTION
Signed-off-by: Cristian Garcia <cgarcia.e88@gmail.com>

## Overview

Introduces `pre-commit` hooks, this will run `black` on each commit if you have it installed, it can also be configured to run other things like `isort` in the future.

## Changes

* Adds the `pre-commit` dependency.
* Changes CI to use `pre-commit` and deletes the `black` step.
* Updates `CONTRIBUTING.md` with info on how to install and run `pre-commit`.

