### PR TITLE
FIX-#431: Moving and adding sampling to backend calculations

### DIFF
--- a/doc/source/reference/config.rst
+++ b/doc/source/reference/config.rst
@@ -144,16 +144,15 @@ Lux currently only support Vega-Lite and matplotlib, and we plan to add support 
 Change the sampling parameters 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To speed up the visualization processing, by default, Lux performs random sampling on datasets with more than 10000 rows. For datasets over 30000 rows, Lux will randomly sample 30000 rows from the dataset.
+To speed up the visualization processing, by default, Lux performs random sampling on datasets with more than 100000 rows. Specifically, for datasets over 100000 rows, Lux will randomly sample 100000 rows from the dataset.
 
-If we want to change these parameters, we can set the `sampling_start` and `sampling_cap` via `lux.config` to change the default form of output. The `sampling_start` is by default set to 10000 and the `sampling_cap` is by default set to 30000. In the following block, we increase these sampling bounds.
+If we want to change these parameters, we can set the `sampling_thresh` via `lux.config` to change the default form of output. The `sampling_thresh` is by default set to 100000. In the following block, we increase this sampling threshold.
 
 .. code-block:: python
 
-    lux.config.sampling_start = 20000
-    lux.config.sampling_cap = 40000
+    lux.config.sampling_thresh = 500000
 
-If we want Lux to use the full dataset in the visualization, we can also disable sampling altogether (but note that this may result in long processing times). Below is an example if disabling the sampling:
+If we want Lux to use the full dataset in the visualization, we can also disable sampling altogether (but note that this may result in long processing times). Below is an example of disabling the sampling:
 
 .. code-block:: python
 

--- a/lux/_config/config.py
+++ b/lux/_config/config.py
@@ -186,13 +186,6 @@ class Config:
 
     @property
     def sampling_thresh(self):
-        """
-        Parameters
-        ----------
-        sample_number : int
-            Number of rows required to begin sampling. Must be smaller or equal to _sampling_cap
-
-        """
         return self._sampling_thresh
 
     @sampling_thresh.setter

--- a/lux/_config/config.py
+++ b/lux/_config/config.py
@@ -44,8 +44,7 @@ class Config:
         #####################################
         #### Optimization Configurations ####
         #####################################
-        self._sampling_start = 100000
-        self._sampling_cap = 1000000
+        self._sampling_thresh = 100000
         self._sampling_flag = True
         self._heatmap_flag = True
         self._heatmap_start = 5000
@@ -186,34 +185,7 @@ class Config:
             )
 
     @property
-    def sampling_cap(self):
-        """
-        Parameters
-        ----------
-        sample_number : int
-            Cap on the number of rows to sample. Must be larger than _sampling_start
-        """
-        return self._sampling_cap
-
-    @sampling_cap.setter
-    def sampling_cap(self, sample_number: int) -> None:
-        """
-        Parameters
-        ----------
-        sample_number : int
-            Cap on the number of rows to sample. Must be larger than _sampling_start
-        """
-        if type(sample_number) == int:
-            assert sample_number >= self._sampling_start
-            self._sampling_cap = sample_number
-        else:
-            warnings.warn(
-                "The cap on the number samples must be an integer.",
-                stacklevel=2,
-            )
-
-    @property
-    def sampling_start(self):
+    def sampling_thresh(self):
         """
         Parameters
         ----------
@@ -221,20 +193,19 @@ class Config:
             Number of rows required to begin sampling. Must be smaller or equal to _sampling_cap
 
         """
-        return self._sampling_start
+        return self._sampling_thresh
 
-    @sampling_start.setter
-    def sampling_start(self, sample_number: int) -> None:
+    @sampling_thresh.setter
+    def sampling_thresh(self, sample_number: int) -> None:
         """
         Parameters
         ----------
         sample_number : int
-            Number of rows required to begin sampling. Must be smaller or equal to _sampling_cap
+            Number of rows required to begin sampling.
 
         """
         if type(sample_number) == int:
-            assert sample_number <= self._sampling_cap
-            self._sampling_start = sample_number
+            self._sampling_thresh = sample_number
         else:
             warnings.warn(
                 "The sampling starting point must be an integer.",

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -53,22 +53,13 @@ class PandasExecutor(Executor):
         ldf : LuxDataFrame
         """
         SAMPLE_FLAG = lux.config.sampling
-        SAMPLE_START = lux.config.sampling_start
-        SAMPLE_CAP = lux.config.sampling_cap
-        SAMPLE_FRAC = 0.75
+        SAMPLE_THRESH = lux.config.sampling_thresh
 
-        if SAMPLE_FLAG and len(ldf) > SAMPLE_CAP:
+        if SAMPLE_FLAG and len(ldf) > SAMPLE_THRESH:
             if ldf._sampled is None:  # memoize unfiltered sample df
-                ldf._sampled = ldf.sample(n=SAMPLE_CAP, random_state=1)
+                ldf._sampled = ldf.sample(n=SAMPLE_THRESH, random_state=1)
             ldf._message.add_unique(
-                f"Large dataframe detected: Lux is only visualizing a sample capped at {SAMPLE_CAP} rows.",
-                priority=99,
-            )
-        elif SAMPLE_FLAG and len(ldf) > SAMPLE_START:
-            if ldf._sampled is None:  # memoize unfiltered sample df
-                ldf._sampled = ldf.sample(frac=SAMPLE_FRAC, random_state=1)
-            ldf._message.add_unique(
-                f"Large dataframe detected: Lux is visualizing a sample of {SAMPLE_FRAC}% of the dataframe ({len(ldf._sampled)} rows).",
+                f"Large dataframe detected: Lux is only visualizing a sample of {SAMPLE_THRESH} rows.",
                 priority=99,
             )
         else:

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -436,16 +436,16 @@ class PandasExecutor(Executor):
                     ldf._data_type[attr] = "geographical"
                 elif pd.api.types.is_float_dtype(ldf.dtypes[attr]):
 
-                    if ldf.cardinality[attr] != len(ldf) and (ldf.cardinality[attr] < 20):
+                    if ldf.cardinality[attr] != ldf._length and (ldf.cardinality[attr] < 20):
                         ldf._data_type[attr] = "nominal"
                     else:
                         ldf._data_type[attr] = "quantitative"
                 elif pd.api.types.is_integer_dtype(ldf.dtypes[attr]):
                     # See if integer value is quantitative or nominal by checking if the ratio of cardinality/data size is less than 0.4 and if there are less than 10 unique values
                     if ldf.pre_aggregated:
-                        if ldf.cardinality[attr] == len(ldf):
+                        if ldf.cardinality[attr] == ldf._length:
                             ldf._data_type[attr] = "nominal"
-                    if ldf.cardinality[attr] / len(ldf) < 0.4 and ldf.cardinality[attr] < 20:
+                    if ldf.cardinality[attr] / ldf._length < 0.4 and ldf.cardinality[attr] < 20:
                         ldf._data_type[attr] = "nominal"
                     else:
                         ldf._data_type[attr] = "quantitative"
@@ -541,7 +541,7 @@ class PandasExecutor(Executor):
         ldf.unique_values = {}
         ldf._min_max = {}
         ldf.cardinality = {}
-        ldf._length = len(ldf)
+        ldf._length = len(ldf_sampled)
 
         for attribute in ldf.columns:
 

--- a/lux/utils/utils.py
+++ b/lux/utils/utils.py
@@ -79,11 +79,11 @@ def check_if_id_like(df, attribute):
     # so that aggregated reset_index fields don't get misclassified
     high_cardinality = df.cardinality[attribute] > 500
     attribute_contain_id = re.search(r"id|ID|iD|Id", str(attribute)) is not None
-    almost_all_vals_unique = df.cardinality[attribute] >= 0.98 * len(df)
+    almost_all_vals_unique = df.cardinality[attribute] >= 0.98 * df._length
     is_string = pd.api.types.is_string_dtype(df[attribute])
     if is_string:
         # For string IDs, usually serial numbers or codes with alphanumerics have a consistent length (eg., CG-39405) with little deviation. For a high cardinality string field but not ID field (like Name or Brand), there is less uniformity across the string lengths.
-        if len(df) > 50:
+        if df._length > 50:
             if lux.config.executor.name == "PandasExecutor":
                 sampled = df[attribute].sample(50, random_state=99)
             else:
@@ -100,14 +100,14 @@ def check_if_id_like(df, attribute):
             and str_length_uniformity
         )
     else:
-        if len(df) >= 2:
+        if df._length >= 2:
             series = df[attribute]
             diff = series.diff()
             evenly_spaced = all(diff.iloc[1:] == diff.iloc[1])
         else:
             evenly_spaced = True
         if attribute_contain_id:
-            almost_all_vals_unique = df.cardinality[attribute] >= 0.75 * len(df)
+            almost_all_vals_unique = df.cardinality[attribute] >= 0.75 * df._length
         return high_cardinality and (almost_all_vals_unique or evenly_spaced)
 
 

--- a/lux/utils/utils.py
+++ b/lux/utils/utils.py
@@ -93,7 +93,6 @@ def check_if_id_like(df, attribute):
         else:
             sampled = df[attribute]
         str_length_uniformity = sampled.apply(lambda x: type(x) == str and len(x)).std() < 3
-        print(high_cardinality, almost_all_vals_unique, str_length_uniformity, attribute)
         return (
             high_cardinality
             and (attribute_contain_id or almost_all_vals_unique)

--- a/lux/utils/utils.py
+++ b/lux/utils/utils.py
@@ -83,7 +83,7 @@ def check_if_id_like(df, attribute):
     is_string = pd.api.types.is_string_dtype(df[attribute])
     if is_string:
         # For string IDs, usually serial numbers or codes with alphanumerics have a consistent length (eg., CG-39405) with little deviation. For a high cardinality string field but not ID field (like Name or Brand), there is less uniformity across the string lengths.
-        if df._length > 50:
+        if len(df) > 50:
             if lux.config.executor.name == "PandasExecutor":
                 sampled = df[attribute].sample(50, random_state=99)
             else:

--- a/lux/utils/utils.py
+++ b/lux/utils/utils.py
@@ -93,6 +93,7 @@ def check_if_id_like(df, attribute):
         else:
             sampled = df[attribute]
         str_length_uniformity = sampled.apply(lambda x: type(x) == str and len(x)).std() < 3
+        print(high_cardinality, almost_all_vals_unique, str_length_uniformity, attribute)
         return (
             high_cardinality
             and (attribute_contain_id or almost_all_vals_unique)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -226,10 +226,10 @@ def test_sampling_flag_config():
     lux.config.early_pruning = False
     import numpy as np
 
-    N = int(1.1 * lux.config.sampling_cap)
+    N = int(1.1 * lux.config.sampling_thresh)
     df = pd.DataFrame({"col1": np.random.rand(N), "col2": np.random.rand(N)})
     df.maintain_recs()
-    assert len(df.recommendation["Correlation"][0].data) == lux.config.sampling_cap
+    assert len(df.recommendation["Correlation"][0].data) == lux.config.sampling_thresh
     lux.config.sampling = True
     lux.config.heatmap = True
     lux.config.early_pruning = True
@@ -239,13 +239,12 @@ def test_sampling_parameters_config():
     df = pd.read_csv("lux/data/car.csv")
     df._ipython_display_()
     assert df.recommendation["Correlation"][0].data.shape[0] == 392
-    lux.config.sampling_start = 50
-    lux.config.sampling_cap = 100
+    old_sampling_thresh = lux.config.sampling_thresh
+    lux.config.sampling_thresh = 100
     df = pd.read_csv("lux/data/car.csv")
     df._ipython_display_()
     assert df.recommendation["Correlation"][0].data.shape[0] == 100
-    lux.config.sampling_cap = 30000
-    lux.config.sampling_start = 10000
+    lux.config.sampling_thresh = old_sampling_thresh
 
 
 def test_heatmap_flag_config():

--- a/tests/test_maintainence.py
+++ b/tests/test_maintainence.py
@@ -102,6 +102,5 @@ def test_intent_cleared_after_vis_data():
     vis.data._ipython_display_()
     all_column_vis = vis.data.current_vis[0]
     assert all_column_vis.get_attr_by_channel("x")[0].attribute == "Year"
-    print(all_column_vis.get_attr_by_channel("y"))
     assert all_column_vis.get_attr_by_channel("y")[0].attribute == "PctForeclosured"
     lux.config.sampling_thresh = old_sampling_thresh

--- a/tests/test_maintainence.py
+++ b/tests/test_maintainence.py
@@ -85,6 +85,8 @@ def test_recs_inplace_operation(global_var):
 
 
 def test_intent_cleared_after_vis_data():
+    old_sampling_thresh = lux.config.sampling_thresh
+    lux.config.sampling_thresh = 10000
     df = pd.read_csv(
         "https://github.com/lux-org/lux-datasets/blob/master/data/real_estate_tutorial.csv?raw=true"
     )
@@ -96,9 +98,10 @@ def test_intent_cleared_after_vis_data():
         lux.Clause("City=Crofton"),
     ]
     df._ipython_display_()
-
     vis = df.recommendation["Similarity"][0]
     vis.data._ipython_display_()
     all_column_vis = vis.data.current_vis[0]
     assert all_column_vis.get_attr_by_channel("x")[0].attribute == "Year"
+    print(all_column_vis.get_attr_by_channel("y"))
     assert all_column_vis.get_attr_by_channel("y")[0].attribute == "PctForeclosured"
+    lux.config.sampling_thresh = old_sampling_thresh


### PR DESCRIPTION
## Overview

This is a branch that builds off of the work done in #432. This moves the sampling to after the Filter and also adds sampling for metadata computation.

## Changes

Changes the `execute` function to move sampling after the Filtering is done, and so the sampling is done on each of the data visualizations. It also edits `compute_data` to sample the data before computing the metadata. All metadata is the metadata associated with the sample, not the full dataset.

## Example Output

N/A
