### PR TITLE
FIX-#419: Handle incompatibility issues between timedelta64 dtypes with Altair

### DIFF
--- a/lux/utils/date_utils.py
+++ b/lux/utils/date_utils.py
@@ -12,8 +12,44 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pandas as pd
+import re
+from typing import Any
+
 import lux
+import pandas as pd
+import numpy as np
+
+timedelta_re = re.compile(r"^timedelta64\[\w+\]$")
+
+
+def is_timedelta64_series(series: pd.Series) -> bool:
+    """
+    Check if the Series object is of timedelta64 type
+
+    Parameters
+    ----------
+    series : pd.Series
+
+    Returns
+    -------
+    is_date: bool
+    """
+    return pd.api.types.is_timedelta64_dtype(series)
+
+
+def timedelta64_to_float_seconds(series: pd.Series) -> pd.Series:
+    """
+    Convert a timedelta64 Series to a float Series in seconds
+
+    Parameters
+    ----------
+    series : pd.Series
+
+    Returns
+    -------
+    series: pd.Series
+    """
+    return series.view(np.int64) / 1_000_000_000
 
 
 def date_formatter(time_stamp, ldf):

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -12,11 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import pandas as pd
-import numpy as np
-import altair as alt
-from lux.utils.date_utils import compute_date_granularity
+import re
+
 import lux
+import numpy as np
+import pandas as pd
+from lux.utils.date_utils import compute_date_granularity
+
+import altair as alt
 
 
 class AltairChart:
@@ -123,14 +126,16 @@ class AltairChart:
 
     @classmethod
     def sanitize_dataframe(self, df):
+        from lux.utils.date_utils import is_timedelta64_series, timedelta64_to_float_seconds
+
         for attr in df.columns:
             # Check if dtype is unrecognized by Altair (#247)
             if str(df[attr].dtype) == "Float64":
                 df[attr] = df[attr].astype(np.float64)
 
-            # Check for timedelta64[ms]
-            if df[attr].dtype.name == "timedelta64[ns]":
-                df[attr] = df[attr].dt.seconds
+            # Check for timedelta64[...] dtype
+            if is_timedelta64_series(df[attr]):
+                df[attr] = timedelta64_to_float_seconds(df[attr])
 
             # Altair can not visualize non-string columns
             # convert all non-string columns in to strings

--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -128,6 +128,10 @@ class AltairChart:
             if str(df[attr].dtype) == "Float64":
                 df[attr] = df[attr].astype(np.float64)
 
+            # Check for timedelta64[ms]
+            if df[attr].dtype.name == "timedelta64[ns]":
+                df[attr] = df[attr].dt.seconds
+
             # Altair can not visualize non-string columns
             # convert all non-string columns in to strings
             df = df.rename(columns={attr: str(attr)})

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -73,3 +73,14 @@ def test_infs():
     df = pd.DataFrame({"c1": c1, "c2": c2, "d1": d1, "d2": d2})
 
     df._ipython_display_()
+
+
+def test_timedeltas():
+    nrows = 100_000
+
+    c1 = np.random.uniform(0, 10, size=nrows)
+    c2 = c1.astype("timedelta64[ms]")
+
+    df = pd.DataFrame({"c1": c1, "c2": c2})
+
+    df._ipython_display_()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -84,3 +84,14 @@ def test_timedeltas():
     df = pd.DataFrame({"c1": c1, "c2": c2})
 
     df._ipython_display_()
+
+
+def test_interval():
+    nrows = 100_000
+
+    c1 = pd.Interval(left=0, right=nrows)
+    c2 = np.random.uniform(0, 10, size=nrows)
+
+    df = pd.DataFrame({"c1": c1, "c2": c2})
+
+    df._ipython_display_()


### PR DESCRIPTION
## Overview
Fixes #419 by handling `timedelta64` columns in `sanitize_dataframe`.

## Changes
* Adds tests for the `timedelta64` and `interval` dtypes.
* Converts `timedelta64` columns to `dt.seconds` inside the `sanitize_dataframe` function.
