### PR TITLE
FIX-#417: Add test for datetime index

### DIFF
--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -86,7 +86,8 @@ def test_datetime_index():
     # continuous
     c1 = np.random.uniform(0, 1, size=nrows)
 
-    df = pd.DataFrame({"c1": c1}, index=dt)
+    data = np.random.uniform(0, 1, size=(nrows,50))
+    df = pd.DataFrame(data, index=dt)
 
     df._ipython_display_()
 

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -78,7 +78,7 @@ def test_infs():
 
 
 def test_datetime_index():
-    nrows = 100000
+    nrows = 10
 
     # create a datetime index, freq in seconds
     dt = pd.date_range("1/1/2019", periods=nrows, freq="1s")

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -16,6 +16,8 @@ from .context import lux
 import pytest
 import pandas as pd
 import numpy as np
+from tempfile import TemporaryDirectory
+from pathlib import Path
 
 
 def test_head_tail(global_var):
@@ -85,5 +87,24 @@ def test_datetime_index():
     c1 = np.random.uniform(0, 1, size=nrows)
 
     df = pd.DataFrame({"c1": c1}, index=dt)
+
+    df._ipython_display_()
+
+
+def test_datetime_index_serialize():
+    nrows = 100000
+
+    # create a datetime index, freq in seconds
+    dt = pd.date_range("1/1/2019", periods=nrows, freq="1s")
+
+    # continuous
+    c1 = np.random.uniform(0, 1, size=nrows)
+
+    df = pd.DataFrame({"c1": c1}, index=dt)
+
+    with TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        df.to_csv(tmpdir / "test.csv")
+        df = pd.read_csv(tmpdir / "test.csv", names=["date", "c1"], index_col="date", header=0)
 
     df._ipython_display_()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -86,7 +86,7 @@ def test_datetime_index():
     # continuous
     c1 = np.random.uniform(0, 1, size=nrows)
 
-    data = np.random.uniform(0, 1, size=(nrows,50))
+    data = np.random.uniform(0, 1, size=(nrows, 50))
     df = pd.DataFrame(data, index=dt)
 
     df._ipython_display_()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -73,3 +73,17 @@ def test_infs():
     df = pd.DataFrame({"c1": c1, "c2": c2, "d1": d1, "d2": d2})
 
     df._ipython_display_()
+
+
+def test_datetime_index():
+    nrows = 100000
+
+    # create a datetime index, freq in seconds
+    dt = pd.date_range("1/1/2019", periods=nrows, freq="1s")
+
+    # continuous
+    c1 = np.random.uniform(0, 1, size=nrows)
+
+    df = pd.DataFrame({"c1": c1}, index=dt)
+
+    df._ipython_display_()


### PR DESCRIPTION
## Overview

Issue #417 suggest datetime index after de-serialization might cause issues, however the error was not reproducible by the added tests.

## Changes
* Adds two tests with dataframes that have datetime indexes.

