### PR TITLE
FIX-#403: Fixes mixed-dtype problem in execute_2D_binning

### DIFF
--- a/lux/core/series.py
+++ b/lux/core/series.py
@@ -148,7 +148,7 @@ class LuxSeries(pd.Series):
             )
             # 2) Mixed type, often a result of a "row" acting as a series (df.iterrows, df.iloc[0])
             # Tolerant for NaNs + 1 type
-            mixed_dtype = len(set([type(val) for val in self.values])) > 2
+            mixed_dtype = len(set(type(val) for val in self.values)) >= 2
             if ldf._pandas_only or is_dtype_series or mixed_dtype:
                 print(series_repr)
                 ldf._pandas_only = False

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -395,16 +395,20 @@ class PandasExecutor(Executor):
             y_attr = vis.get_attr_by_channel("y")[0].attribute
 
             if vis.data[x_attr].dtype == np.dtype('O'):
-                try:
-                    vis.data[x_attr] = vis.data[x_attr].astype(float)
-                except ValueError:
-                    pass
+                mixed_dtype = len(set(type(val) for val in vis.data[x_attr])) >= 2
+                if mixed_dtype:
+                    try:
+                        vis.data[x_attr] = vis.data[x_attr].astype(float)
+                    except ValueError:
+                        pass
 
             if vis.data[y_attr].dtype == np.dtype('O'):
-                try:
-                    vis.data[y_attr] = vis.data[y_attr].astype(float)
-                except ValueError:
-                    pass
+                mixed_dtype = len(set(type(val) for val in vis.data[y_attr])) >= 2
+                if mixed_dtype:
+                    try:
+                        vis.data[y_attr] = vis.data[y_attr].astype(float)
+                    except ValueError:
+                        pass
 
             vis._vis_data["xBin"] = pd.cut(vis._vis_data[x_attr], bins=lux.config.heatmap_bin_size)
             vis._vis_data["yBin"] = pd.cut(vis._vis_data[y_attr], bins=lux.config.heatmap_bin_size)

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -394,17 +394,17 @@ class PandasExecutor(Executor):
             x_attr = vis.get_attr_by_channel("x")[0].attribute
             y_attr = vis.get_attr_by_channel("y")[0].attribute
 
-            def _try_cast_float(series):
-                try:
-                    return series.astype(float)
-                except ValueError:
-                    return series
-
             if vis.data[x_attr].dtype == np.dtype('O'):
-                vis.data[x_attr] = _try_cast_float(vis.data[x_attr])
-            
+                try:
+                    vis.data[x_attr] = vis.data[x_attr].astype(float)
+                except ValueError:
+                    pass
+
             if vis.data[y_attr].dtype == np.dtype('O'):
-                vis.data[y_attr] = _try_cast_float(vis.data[y_attr])
+                try:
+                    vis.data[y_attr] = vis.data[y_attr].astype(float)
+                except ValueError:
+                    pass
 
             vis._vis_data["xBin"] = pd.cut(vis._vis_data[x_attr], bins=lux.config.heatmap_bin_size)
             vis._vis_data["yBin"] = pd.cut(vis._vis_data[y_attr], bins=lux.config.heatmap_bin_size)

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -394,6 +394,12 @@ class PandasExecutor(Executor):
             x_attr = vis.get_attr_by_channel("x")[0].attribute
             y_attr = vis.get_attr_by_channel("y")[0].attribute
 
+            if vis.data[x_attr].dtype == np.dtype('O'):
+                vis.data[x_attr] = vis.data[x_attr].astype(float)
+
+            if vis.data[y_attr].dtype == np.dtype('O'):
+                vis.data[y_attr] = vis.data[y_attr].astype(float)
+
             vis._vis_data["xBin"] = pd.cut(vis._vis_data[x_attr], bins=lux.config.heatmap_bin_size)
             vis._vis_data["yBin"] = pd.cut(vis._vis_data[y_attr], bins=lux.config.heatmap_bin_size)
 

--- a/lux/executor/PandasExecutor.py
+++ b/lux/executor/PandasExecutor.py
@@ -394,11 +394,17 @@ class PandasExecutor(Executor):
             x_attr = vis.get_attr_by_channel("x")[0].attribute
             y_attr = vis.get_attr_by_channel("y")[0].attribute
 
-            if vis.data[x_attr].dtype == np.dtype('O'):
-                vis.data[x_attr] = vis.data[x_attr].astype(float)
+            def _try_cast_float(series):
+                try:
+                    return series.astype(float)
+                except ValueError:
+                    return series
 
+            if vis.data[x_attr].dtype == np.dtype('O'):
+                vis.data[x_attr] = _try_cast_float(vis.data[x_attr])
+            
             if vis.data[y_attr].dtype == np.dtype('O'):
-                vis.data[y_attr] = vis.data[y_attr].astype(float)
+                vis.data[y_attr] = _try_cast_float(vis.data[y_attr])
 
             vis._vis_data["xBin"] = pd.cut(vis._vis_data[x_attr], bins=lux.config.heatmap_bin_size)
             vis._vis_data["yBin"] = pd.cut(vis._vis_data[y_attr], bins=lux.config.heatmap_bin_size)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -131,3 +131,13 @@ def test_datetime_index_serialize():
         df = pd.read_csv(tmpdir / "test.csv", names=["date", "c1"], index_col="date", header=0)
 
     df._ipython_display_()
+
+
+def test_cut_mixed_types():
+
+    a = [1, "2", 3, "4", 5, "6", 7, "8", 9, "10"] * 1_000
+    b = np.random.uniform(0, 1, size=len(a))
+
+    df = pd.DataFrame({"a": a, "b": b})
+
+    df._ipython_display_()

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -135,7 +135,7 @@ def test_datetime_index_serialize():
 
 def test_cut_mixed_types():
 
-    a = [1, "2", 3, "4", 5, "6", 7, "8", 9, "10"] * 1_000
+    a = [1, "2", 3, "4", 5, "6", 7, "8", 9, "10"] * 1000
     b = np.random.uniform(0, 1, size=len(a))
 
     df = pd.DataFrame({"a": a, "b": b})


### PR DESCRIPTION
## Overview

Mixed dtype columns cause `execute_2D_binning` to crash when trying to bin via `pd.cut`, this error shows up frequently in users code (#403, #394).

## Changes

* Adds a test using mixed dtypes
* Tries to cast series to `float` inside `execute_2D_binning`
