### PR TITLE
FIX-#447: Add show_versions helper for debugging

### DIFF
--- a/lux/__init__.py
+++ b/lux/__init__.py
@@ -21,6 +21,7 @@ from lux.utils.tracing_utils import LuxTracer
 from ._version import __version__, version_info
 from lux._config import config
 from lux._config.config import warning_format
+from lux.utils.debug_utils import show_versions
 
 from lux._config import Config
 

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -1,0 +1,22 @@
+def show_versions():
+    """
+    Prints the versions of the principal packages used by Lux for debugging purposes.
+    """
+    import pandas as pd
+    import lux
+    import luxwidget
+
+    df = pd.DataFrame(
+        [
+            ("lux", lux.__version__),
+            ("pandas", pd.__version__),
+            ("luxwidget", luxwidget.__version__),
+        ],
+        columns=["Package", "Version"],
+    )
+
+    print(df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    show_versions()

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -7,6 +7,7 @@ def show_versions():
     import luxwidget
     import matplotlib
     import altair
+import platform
 
     df = pd.DataFrame(
         [

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -1,13 +1,25 @@
-def show_versions():
+from typing import Optional
+
+
+def show_versions(return_string: bool = False) -> Optional[str]:
     """
     Prints the versions of the principal packages used by Lux for debugging purposes.
+
+    Parameters
+    ----------
+    return_string: Whether to return the versions as a string or print them.
+
+    Returns
+    -------
+    If return_string is True, returns a string with the versions else the versions
+    are printed and None is returned.
     """
     import pandas as pd
     import lux
     import luxwidget
     import matplotlib
     import altair
-import platform
+    import platform
 
     df = pd.DataFrame(
         [
@@ -18,10 +30,15 @@ import platform
             ("matplotlib", matplotlib.__version__),
             ("altair", altair.__version__),
         ],
-        columns=["", "Version"]
+        columns=["", "Version"],
     )
 
-    print(df.to_string(index=False))
+    str_rep = df.to_string(index=False)
+
+    if return_string:
+        return str_rep
+    else:
+        print(str_rep)
 
 
 if __name__ == "__main__":

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -5,12 +5,16 @@ def show_versions():
     import pandas as pd
     import lux
     import luxwidget
+    import matplotlib
+    import altair
 
     df = pd.DataFrame(
         [
             ("lux", lux.__version__),
             ("pandas", pd.__version__),
             ("luxwidget", luxwidget.__version__),
+            ("matplotlib", matplotlib.__version__),
+            ("altair", altair.__version__),
         ],
         columns=["Package", "Version"],
     )

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -1,3 +1,5 @@
+import re
+import subprocess
 from typing import Optional
 
 
@@ -14,12 +16,16 @@ def show_versions(return_string: bool = False) -> Optional[str]:
     If return_string is True, returns a string with the versions else the versions
     are printed and None is returned.
     """
-    import pandas as pd
+    import platform
+
+    import altair
     import lux
     import luxwidget
     import matplotlib
-    import altair
-    import platform
+    import pandas as pd
+
+    jupyter_versions_str = subprocess.check_output(["jupyter", "--version"])
+    jupyter_versions = re.findall(r"(\S+)\s+: (.+)\S*", jupyter_versions_str.decode("utf-8"))
 
     df = pd.DataFrame(
         [
@@ -29,11 +35,12 @@ def show_versions(return_string: bool = False) -> Optional[str]:
             ("luxwidget", luxwidget.__version__),
             ("matplotlib", matplotlib.__version__),
             ("altair", altair.__version__),
-        ],
+        ]
+        + jupyter_versions,
         columns=["", "Version"],
     )
 
-    str_rep = df.to_string(index=False)
+    str_rep = df.to_string(index=False, justify="left")
 
     if return_string:
         return str_rep

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -18,7 +18,7 @@ import platform
             ("matplotlib", matplotlib.__version__),
             ("altair", altair.__version__),
         ],
-        columns=["Package", "Version"],
+        columns=["", "Version"]
     )
 
     print(df.to_string(index=False))

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -11,6 +11,7 @@ import platform
 
     df = pd.DataFrame(
         [
+            ("python", platform.python_version()),
             ("lux", lux.__version__),
             ("pandas", pd.__version__),
             ("luxwidget", luxwidget.__version__),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,3 +14,7 @@ class TestDebugUtils:
         assert "luxwidget" in versions
         assert "matplotlib" in versions
         assert "altair" in versions
+
+
+if __name__ == "__main__":
+    TestDebugUtils().test_show_info()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import lux
+
+
+class TestDebugUtils:
+    def test_show_info(self):
+
+        versions = lux.show_versions(return_string=True)
+
+        assert versions is not None
+
+        assert "python" in versions
+        assert "lux" in versions
+        assert "pandas" in versions
+        assert "luxwidget" in versions
+        assert "matplotlib" in versions
+        assert "altair" in versions


### PR DESCRIPTION
## Overview

Adds a `show_versions()` function that prints the lux, pandas, and luxwidget versions. We can ask for this information for debugging.
