### PR TITLE
FIX-#447: Add debug information if luxwidget extension is not enabled.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,16 +12,27 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Please describe the steps needed to reproduce the behavior. For example:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Using this data: `df = ...`
+2. Go to '...'
+3. Click on '....'
+4. Scroll down to '....'
+5. See error
+
+**Important**: Make sure to provide a sample of (preferably synthetic) data 
+that can trigger the error based on the instructions.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+
+**Debugging information**
+Please run the following command and paste the output here:
+
+```bash
+python -c "import lux; lux.debug_info()"
+```
 
 **Additional context**
 Add any other context about the problem here.

--- a/lux/__init__.py
+++ b/lux/__init__.py
@@ -21,7 +21,7 @@ from lux.utils.tracing_utils import LuxTracer
 from ._version import __version__, version_info
 from lux._config import config
 from lux._config.config import warning_format
-from lux.utils.debug_utils import show_versions
+from lux.utils.debug_utils import show_versions, check_luxwidget_enabled
 
 from lux._config import Config
 
@@ -30,3 +30,4 @@ config = Config()
 from lux.action.default import register_default_actions
 
 register_default_actions()
+check_luxwidget_enabled()

--- a/lux/__init__.py
+++ b/lux/__init__.py
@@ -21,7 +21,7 @@ from lux.utils.tracing_utils import LuxTracer
 from ._version import __version__, version_info
 from lux._config import config
 from lux._config.config import warning_format
-from lux.utils.debug_utils import show_versions, check_luxwidget_enabled
+from lux.utils.debug_utils import debug_info, check_luxwidget_enabled
 
 from lux._config import Config
 

--- a/lux/__init__.py
+++ b/lux/__init__.py
@@ -21,6 +21,7 @@ from lux.utils.tracing_utils import LuxTracer
 from ._version import __version__, version_info
 from lux._config import config
 from lux._config.config import warning_format
+from lux.utils.debug_utils import show_versions
 
 from lux._config import Config
 

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -1,3 +1,10 @@
+import json
+from pathlib import Path
+import re
+import subprocess
+import typing as tp
+
+
 def show_versions():
     """
     Prints the versions of the principal packages used by Lux for debugging purposes.
@@ -22,5 +29,94 @@ def show_versions():
     print(df.to_string(index=False))
 
 
+def notebook_enabled() -> tp.Tuple[bool, str]:
+    status, nbextension_list = subprocess.getstatusoutput("jupyter nbextension list")
+
+    if status != 0:
+        return False, "Failed to run 'jupyter nbextension list'"
+
+    match = re.findall(r"config dir:(.*)\n", nbextension_list)
+
+    if match:
+        config_dir = match[0].strip()
+    else:
+        return False, "No 'config dir' found in 'jupyter nbextension list'"
+
+    notebook_json = Path(config_dir) / "notebook.json"
+
+    if not notebook_json.exists():
+        return False, f"'{notebook_json}' does not exist"
+
+    extensions = json.loads(notebook_json.read_text())
+
+    if "load_extensions" not in extensions:
+        return False, "'load_extensions' not in 'notebook.json'"
+    elif "luxwidget/extension" not in extensions["load_extensions"]:
+        return False, "'luxwidget/extension' not in 'load_extensions'"
+
+    extension_enabled = extensions["load_extensions"]["luxwidget/extension"]
+
+    if not extension_enabled:
+        return False, "luxwidget is installed but not enabled"
+
+    return True, ""
+
+
+def lab_enabled() -> tp.Tuple[bool, str]:
+    status_str, lab_list = subprocess.getstatusoutput("jupyter labextension list")
+
+    if status_str != 0:
+        return False, "Failed to run 'jupyter labextension list'"
+
+    match = re.findall(r"luxwidget (\S+) (\S+) (\S+)", lab_list)
+
+    if match:
+        version_str, enabled_str, status_str = (_strip_ansi(s) for s in match[0])
+    else:
+        return False, "'luxwidget' not found in 'jupyter labextension list'"
+
+    if enabled_str != "enabled":
+        enabled_str = re.sub(r"\033\[(\d|;)+?m", "", enabled_str)
+        return False, f"luxwidget is installed but currently '{enabled_str}'"
+
+    if status_str != "OK":
+        return False, f"luxwidget is installed but currently '{status_str}'"
+
+    return True, ""
+
+
+def is_lab_notebook():
+    import re
+    import psutil
+
+    cmd = psutil.Process().parent().cmdline()
+
+    return any(re.search("jupyter-lab", x) for x in cmd)
+
+
+def check_luxwidget_enabled():
+
+    # get the ipython shell
+    import IPython
+
+    ip = IPython.get_ipython()
+
+    # return if the shell is not available
+    if ip is None:
+        return
+
+    if is_lab_notebook():
+        enabled, msg = lab_enabled()
+    else:
+        enabled, msg = notebook_enabled()
+
+    if not enabled:
+        print(f"WARNING: luxwidget is not enabled. Got: {msg}")
+
+
+def _strip_ansi(source):
+    return re.sub(r"\033\[(\d|;)+?m", "", source)
+
+
 if __name__ == "__main__":
-    show_versions()
+    check_luxwidget_enabled()

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -1,0 +1,22 @@
+def show_versions():
+    """
+    Prints the versions of the principal packages used by Lux for debugging purposes.
+    """
+    import pandas as pd
+    import lux
+    import luxwidget
+
+    df = pd.DataFrame(
+        [
+            ("lux", lux.__version__),
+            ("pandas", pd.__version__),
+            ("luxwidget", luxwidget.__version__),
+        ],
+        columns=["Package", "Version"],
+    )
+
+    print(df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    show_versions()

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -9,9 +9,13 @@ import subprocess
 from typing import Optional
 
 
-def show_versions(return_string: bool = False) -> Optional[str]:
+def debug_info(return_string: bool = False) -> Optional[str]:
     """
-    Prints the versions of the principal packages used by Lux for debugging purposes.
+    Prints all the informatation that could be useful for debugging purposes.
+    Currently, this includes:
+
+    * The versions of the packages used by Lux
+    * Info about the current state of luxwidget
 
     Parameters
     ----------
@@ -19,8 +23,8 @@ def show_versions(return_string: bool = False) -> Optional[str]:
 
     Returns
     -------
-    If return_string is True, returns a string with the versions else the versions
-    are printed and None is returned.
+    If return_string is True, returns a string with the debug info else the
+    string will be printed and None is returned.
     """
     import platform
 
@@ -49,8 +53,13 @@ def show_versions(return_string: bool = False) -> Optional[str]:
     str_rep = df.to_string(index=False, justify="left")
     luxwidget_msg = check_luxwidget_enabled(return_string=True)
 
+    assert str_rep is not None
+    assert luxwidget_msg is not None
+
     if luxwidget_msg:
-        str_rep += "\n" + luxwidget_msg
+        str_rep += "\n\n" + luxwidget_msg + "\n"
+    else:
+        str_rep += "\n\n" + "luxwidget is enabled" + "\n"
 
     if return_string:
         return str_rep

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -5,12 +5,16 @@ def show_versions():
     import pandas as pd
     import lux
     import luxwidget
+    import matplotlib
+    import altair
 
     df = pd.DataFrame(
         [
             ("lux", lux.__version__),
             ("pandas", pd.__version__),
             ("luxwidget", luxwidget.__version__),
+            ("matplotlib", matplotlib.__version__),
+            ("altair", altair.__version__),
         ],
         columns=["Package", "Version"],
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ matplotlib>=3.0.0
 lux-widget>=0.1.4
 autopep8>=1.5
 iso3166
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ matplotlib>=3.0.0
 lux-widget>=0.1.4
 autopep8>=1.5
 iso3166
-psutil
+psutil>=5.9.0
+sh>=1.14.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,9 @@ import lux
 
 
 class TestDebugUtils:
-    def test_show_info(self):
+    def test_debug_info(self):
 
-        versions = lux.show_versions(return_string=True)
+        versions = lux.debug_info(return_string=True)
 
         assert versions is not None
 
@@ -17,4 +17,4 @@ class TestDebugUtils:
 
 
 if __name__ == "__main__":
-    TestDebugUtils().test_show_info()
+    TestDebugUtils().test_debug_info()


### PR DESCRIPTION
## Overview

Per #447, the idea is to add some debug information (i.e. a warning) in case `luxwidget` is not installed/enabled. 
