### PR TITLE
FIX-#447: Add debug information if luxwidget extension is not enabled.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,10 +28,11 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Debugging information**
-Please run the following command and paste the output here:
+Please run the following code in your Jupyter Notebook/Lab:
 
-```bash
-python -c "import lux; lux.debug_info()"
+```python
+import lux
+lux.debug_info()
 ```
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,16 +12,27 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Please describe the steps needed to reproduce the behavior. For example:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. Using this data: `df = ...`
+2. Go to '...'
+3. Click on '....'
+4. Scroll down to '....'
+5. See error
+
+**Important**: Make sure to provide a sample of (preferably synthetic) data 
+that can trigger the error based on the instructions.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+
+**Debugging information**
+Please run the following command and paste the output here:
+
+```bash
+python -c "import lux; lux.debug_info()"
+```
 
 **Additional context**
 Add any other context about the problem here.

--- a/lux/__init__.py
+++ b/lux/__init__.py
@@ -21,7 +21,7 @@ from lux.utils.tracing_utils import LuxTracer
 from ._version import __version__, version_info
 from lux._config import config
 from lux._config.config import warning_format
-from lux.utils.debug_utils import show_versions
+from lux.utils.debug_utils import debug_info, check_luxwidget_enabled
 
 from lux._config import Config
 
@@ -30,3 +30,4 @@ config = Config()
 from lux.action.default import register_default_actions
 
 register_default_actions()
+check_luxwidget_enabled()

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -9,19 +9,16 @@ import subprocess
 from typing import Optional
 
 
-def debug_info(return_string: bool = False) -> Optional[str]:
+def show_versions(return_string: bool = False) -> Optional[str]:
     """
-    Prints all the informatation that could be useful for debugging purposes.
-    Currently, this includes:
-    * The versions of the packages used by Lux
-    * Info about the current state of luxwidget
+    Prints the versions of the principal packages used by Lux for debugging purposes.
     Parameters
     ----------
     return_string: Whether to return the versions as a string or print them.
     Returns
     -------
-    If return_string is True, returns a string with the debug info else the
-    string will be printed and None is returned.
+    If return_string is True, returns a string with the versions else the versions
+    are printed and None is returned.
     """
     import platform
 
@@ -31,9 +28,9 @@ def debug_info(return_string: bool = False) -> Optional[str]:
     import matplotlib
     import pandas as pd
 
+    header = "Package Versions\n----------------\n"
     jupyter_versions_str = subprocess.check_output(["jupyter", "--version"])
     jupyter_versions = re.findall(r"(\S+)\s+: (.+)\S*", jupyter_versions_str.decode("utf-8"))
-
     df = pd.DataFrame(
         [
             ("python", platform.python_version()),
@@ -47,16 +44,38 @@ def debug_info(return_string: bool = False) -> Optional[str]:
         columns=["", "Version"],
     )
 
-    str_rep = df.to_string(index=False, justify="left")
+    str_rep = header + df.to_string(index=False, justify="left")
+
+    if return_string:
+        return str_rep
+    else:
+        print(str_rep)
+
+
+def debug_info(return_string: bool = False) -> Optional[str]:
+    """
+    Prints all the informatation that could be useful for debugging purposes.
+    Currently, this includes:
+
+    * The versions of the packages used by Lux
+    * Info about the current state of luxwidget
+
+    Parameters
+    ----------
+    return_string: Whether to return the versions as a string or print them.
+
+    Returns
+    -------
+    If return_string is True, returns a string with the debug info else the
+    string will be printed and None is returned.
+    """
+    str_rep = show_versions(return_string=True)
     luxwidget_msg = check_luxwidget_enabled(return_string=True)
 
     assert str_rep is not None
     assert luxwidget_msg is not None
-
-    if luxwidget_msg:
-        str_rep += "\n\n" + luxwidget_msg + "\n"
-    else:
-        str_rep += "\n\n" + "luxwidget is enabled" + "\n"
+    header = "Widget Setup\n-------------\n"
+    str_rep += "\n\n" + header + luxwidget_msg + "\n"
 
     if return_string:
         return str_rep
@@ -68,31 +87,31 @@ def notebook_enabled() -> tp.Tuple[bool, str]:
     status, nbextension_list = subprocess.getstatusoutput("jupyter nbextension list")
 
     if status != 0:
-        return False, "Failed to run 'jupyter nbextension list'"
+        return False, "❌ Failed to run 'jupyter nbextension list'\n"
 
     match = re.findall(r"config dir:(.*)\n", nbextension_list)
 
     if match:
         config_dir = match[0].strip()
     else:
-        return False, "No 'config dir' found in 'jupyter nbextension list'"
+        return False, "❌ No 'config dir' found in 'jupyter nbextension list'\n"
 
     notebook_json = Path(config_dir) / "notebook.json"
 
     if not notebook_json.exists():
-        return False, f"'{notebook_json}' does not exist"
+        return False, f"'{notebook_json}' does not exist\n"
 
     extensions = json.loads(notebook_json.read_text())
 
     if "load_extensions" not in extensions:
-        return False, "'load_extensions' not in 'notebook.json'"
+        return False, "❌ 'load_extensions' not in 'notebook.json'\n"
     elif "luxwidget/extension" not in extensions["load_extensions"]:
-        return False, "'luxwidget/extension' not in 'load_extensions'"
+        return False, "❌ 'luxwidget/extension' not in 'load_extensions'\n"
 
     extension_enabled = extensions["load_extensions"]["luxwidget/extension"]
 
     if not extension_enabled:
-        return False, "luxwidget is installed but not enabled"
+        return False, "❌ luxwidget is installed but not enabled\n"
 
     return True, ""
 
@@ -101,21 +120,24 @@ def lab_enabled() -> tp.Tuple[bool, str]:
     status_str, lab_list = subprocess.getstatusoutput("jupyter labextension list")
 
     if status_str != 0:
-        return False, "Failed to run 'jupyter labextension list'"
+        return (
+            False,
+            "❌ Failed to run 'jupyter labextension list'. Do you have Jupyter Lab installed in this environment?",
+        )
 
     match = re.findall(r"luxwidget (\S+) (\S+) (\S+)", lab_list)
 
     if match:
         version_str, enabled_str, status_str = (_strip_ansi(s) for s in match[0])
     else:
-        return False, "'luxwidget' not found in 'jupyter labextension list'"
+        return False, "❌ 'luxwidget' not found in 'jupyter labextension list'\n"
 
     if enabled_str != "enabled":
         enabled_str = re.sub(r"\033\[(\d|;)+?m", "", enabled_str)
-        return False, f"luxwidget is installed but currently '{enabled_str}'"
+        return False, f"❌ luxwidget is installed but currently '{enabled_str}'\n"
 
     if status_str != "OK":
-        return False, f"luxwidget is installed but currently '{status_str}'"
+        return False, f"❌ luxwidget is installed but currently '{status_str}'\n"
 
     return True, ""
 
@@ -137,22 +159,35 @@ def check_luxwidget_enabled(return_string: bool = False) -> Optional[str]:
 
     # return if the shell is not available
     if ip is None:
-        return ""
+        return "❌ IPython shell note available.\nPlease note that Lux must be used within a notebook interface (e.g., Jupyter notebook, Jupyter Lab, JupyterHub, or VSCode)\n"
+    is_lab = is_lab_notebook()
 
-    if is_lab_notebook():
-        enabled, msg = lab_enabled()
-    else:
-        enabled, msg = notebook_enabled()
+    if is_lab:
+        msg = "✅ Jupyter Lab Running\n"
+        enabled, emsg = lab_enabled()
+        msg = msg + emsg
+        if not enabled:
+            msg += f"❌ WARNING: luxwidget is not enabled in Jupyter Lab."
+            msg += "You may need to run the following code in your command line:\n"
+            msg += "  jupyter labextension install @jupyter-widgets/jupyterlab-manager\n"
+            msg += "  jupyter labextension install luxwidget"
+        else:
+            msg += "✅ luxwidget is enabled"
 
-    if not enabled:
-        msg = f"WARNING: luxwidget is not enabled. Got: {msg}"
     else:
-        msg = ""
+        msg = "✅ Jupyter Notebook Running\n"
+        enabled, emsg = notebook_enabled()
+        msg = msg + emsg
+        if not enabled:
+            msg += "❌ WARNING: luxwidget is not enabled in Jupyter Notebook.\n"
+            msg += "You may need to run the following code in your command line:\n"
+            msg += "  jupyter nbextension install --py luxwidget\n"
+            msg += "  jupyter nbextension enable --py luxwidget"
+        else:
+            msg += "✅ luxwidget is enabled"
 
     if return_string:
         return msg
-    else:
-        print(msg)
 
 
 def _strip_ansi(source):

--- a/lux/utils/debug_utils.py
+++ b/lux/utils/debug_utils.py
@@ -1,20 +1,27 @@
+import json
+from pathlib import Path
+import re
+import subprocess
+import typing as tp
+
 import re
 import subprocess
 from typing import Optional
 
 
-def show_versions(return_string: bool = False) -> Optional[str]:
+def debug_info(return_string: bool = False) -> Optional[str]:
     """
-    Prints the versions of the principal packages used by Lux for debugging purposes.
-
+    Prints all the informatation that could be useful for debugging purposes.
+    Currently, this includes:
+    * The versions of the packages used by Lux
+    * Info about the current state of luxwidget
     Parameters
     ----------
     return_string: Whether to return the versions as a string or print them.
-
     Returns
     -------
-    If return_string is True, returns a string with the versions else the versions
-    are printed and None is returned.
+    If return_string is True, returns a string with the debug info else the
+    string will be printed and None is returned.
     """
     import platform
 
@@ -41,6 +48,15 @@ def show_versions(return_string: bool = False) -> Optional[str]:
     )
 
     str_rep = df.to_string(index=False, justify="left")
+    luxwidget_msg = check_luxwidget_enabled(return_string=True)
+
+    assert str_rep is not None
+    assert luxwidget_msg is not None
+
+    if luxwidget_msg:
+        str_rep += "\n\n" + luxwidget_msg + "\n"
+    else:
+        str_rep += "\n\n" + "luxwidget is enabled" + "\n"
 
     if return_string:
         return str_rep
@@ -48,5 +64,100 @@ def show_versions(return_string: bool = False) -> Optional[str]:
         print(str_rep)
 
 
+def notebook_enabled() -> tp.Tuple[bool, str]:
+    status, nbextension_list = subprocess.getstatusoutput("jupyter nbextension list")
+
+    if status != 0:
+        return False, "Failed to run 'jupyter nbextension list'"
+
+    match = re.findall(r"config dir:(.*)\n", nbextension_list)
+
+    if match:
+        config_dir = match[0].strip()
+    else:
+        return False, "No 'config dir' found in 'jupyter nbextension list'"
+
+    notebook_json = Path(config_dir) / "notebook.json"
+
+    if not notebook_json.exists():
+        return False, f"'{notebook_json}' does not exist"
+
+    extensions = json.loads(notebook_json.read_text())
+
+    if "load_extensions" not in extensions:
+        return False, "'load_extensions' not in 'notebook.json'"
+    elif "luxwidget/extension" not in extensions["load_extensions"]:
+        return False, "'luxwidget/extension' not in 'load_extensions'"
+
+    extension_enabled = extensions["load_extensions"]["luxwidget/extension"]
+
+    if not extension_enabled:
+        return False, "luxwidget is installed but not enabled"
+
+    return True, ""
+
+
+def lab_enabled() -> tp.Tuple[bool, str]:
+    status_str, lab_list = subprocess.getstatusoutput("jupyter labextension list")
+
+    if status_str != 0:
+        return False, "Failed to run 'jupyter labextension list'"
+
+    match = re.findall(r"luxwidget (\S+) (\S+) (\S+)", lab_list)
+
+    if match:
+        version_str, enabled_str, status_str = (_strip_ansi(s) for s in match[0])
+    else:
+        return False, "'luxwidget' not found in 'jupyter labextension list'"
+
+    if enabled_str != "enabled":
+        enabled_str = re.sub(r"\033\[(\d|;)+?m", "", enabled_str)
+        return False, f"luxwidget is installed but currently '{enabled_str}'"
+
+    if status_str != "OK":
+        return False, f"luxwidget is installed but currently '{status_str}'"
+
+    return True, ""
+
+
+def is_lab_notebook():
+    import re
+    import psutil
+
+    cmd = psutil.Process().parent().cmdline()
+
+    return any(re.search("jupyter-lab", x) for x in cmd)
+
+
+def check_luxwidget_enabled(return_string: bool = False) -> Optional[str]:
+    # get the ipython shell
+    import IPython
+
+    ip = IPython.get_ipython()
+
+    # return if the shell is not available
+    if ip is None:
+        return ""
+
+    if is_lab_notebook():
+        enabled, msg = lab_enabled()
+    else:
+        enabled, msg = notebook_enabled()
+
+    if not enabled:
+        msg = f"WARNING: luxwidget is not enabled. Got: {msg}"
+    else:
+        msg = ""
+
+    if return_string:
+        return msg
+    else:
+        print(msg)
+
+
+def _strip_ansi(source):
+    return re.sub(r"\033\[(\d|;)+?m", "", source)
+
+
 if __name__ == "__main__":
-    show_versions()
+    check_luxwidget_enabled()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ matplotlib>=3.0.0
 lux-widget>=0.1.4
 autopep8>=1.5
 iso3166
+psutil>=5.9.0
+sh>=1.14.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,9 @@ import lux
 
 
 class TestDebugUtils:
-    def test_show_info(self):
+    def test_debug_info(self):
 
-        versions = lux.show_versions(return_string=True)
+        versions = lux.debug_info(return_string=True)
 
         assert versions is not None
 
@@ -17,4 +17,4 @@ class TestDebugUtils:
 
 
 if __name__ == "__main__":
-    TestDebugUtils().test_show_info()
+    TestDebugUtils().test_debug_info()


### PR DESCRIPTION
## Overview

Per #447, add some debug information (i.e. a warning) in case `luxwidget` is not installed/enabled. 

<img src="https://user-images.githubusercontent.com/5554675/153776617-743515b5-5ed0-4c14-b041-243442b29670.png" width="60%"></img>

