### PR TITLE
FIX-#298: Abbrev long filter values and add test

### DIFF
--- a/lux/vislib/altair/AltairChart.py
+++ b/lux/vislib/altair/AltairChart.py
@@ -117,6 +117,8 @@ class AltairChart:
     def add_title(self):
         chart_title = self.vis.title
         if chart_title:
+            if len(chart_title) > 25:
+                chart_title = chart_title[:15] + "..." + chart_title[-10:]
             self.chart = self.chart.encode().properties(title=chart_title)
             if self.code != "":
                 self.code += f"chart = chart.encode().properties(title = '{chart_title}')"

--- a/lux/vislib/matplotlib/MatplotlibChart.py
+++ b/lux/vislib/matplotlib/MatplotlibChart.py
@@ -68,6 +68,9 @@ class MatplotlibChart:
     def add_title(self):
         chart_title = self.vis.title
         if chart_title:
+
+            if len(chart_title) > 25:
+                chart_title = chart_title[:15] + "..." + chart_title[-10:]
             self.ax.set_title(chart_title)
             self.code += f"ax.set_title('{chart_title}')\n"
 

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -582,3 +582,23 @@ def test_intent_override_all_column():
     assert (
         "y = alt.Y('Record', type= 'quantitative', title='Number of Records'" in current_vis_code
     ), "All column not overriden by intent"
+
+
+def test_abbrev_title():
+    long_content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    dataset = [
+        {"long_attr": long_content, "normal": 3, "normal2": 1},
+        {"long_attr": long_content, "normal": 3, "normal2": 1},
+        {"long_attr": long_content, "normal": 2, "normal2": 1},
+        {"long_attr": long_content, "normal": 4, "normal2": 1},
+    ]
+    df = pd.DataFrame(dataset)
+    lux.config.plotting_backend = "matplotlib"
+    vis = Vis(["normal2", "normal", f"long_attr={long_content}"], df)
+    vis_code = vis.to_matplotlib()
+    print(vis_code)
+    assert "long_attr = Lor...t laborum.'" in vis_code
+
+    vis_code = vis.to_altair()
+    print(vis_code)
+    assert "long_attr = Lor...t laborum.'" in vis_code


### PR DESCRIPTION
## Overview

If a title is longer than 25 characters (due to a long filter value), it is abbreviated so the visualization is not exceedingly wide or have a title that is cut off. Referencing #298  

## Changes

The long text is truncated in both Altair and Matplotlib charts so that chart_title = chart_title[:15] + "..." + chart_title[-10:].
tests/test_vis.py also includes test_abbrev_title to test for this behavior.

## Example Output
<img width="375" alt="Screen Shot 2022-03-08 at 12 19 43 PM" src="https://user-images.githubusercontent.com/17665008/157318248-9eb04887-ed6d-4f97-8762-6586fd92f8f2.png">

