### PR TITLE
FIX-#464: Remove sh dependency

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,7 @@
 
 import subprocess
 
-subprocess.call(["sh", "./docbuild.sh"])
+# subprocess.call(["sh", "./docbuild.sh"])
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/lux/_version.py
+++ b/lux/_version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-version_info = (0, 5, 0)
+version_info = (0, 5, 1)
 __version__ = ".".join(map(str, version_info))

--- a/lux/_version.py
+++ b/lux/_version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-version_info = (0, 4, 0)
+version_info = (0, 5, 0)
 __version__ = ".".join(map(str, version_info))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ lux-widget>=0.1.4
 autopep8>=1.5
 iso3166
 psutil>=5.9.0
-sh>=1.14.0
+sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ lux-widget>=0.1.4
 autopep8>=1.5
 iso3166
 psutil>=5.9.0
-sh
+# sh


### PR DESCRIPTION
# Overview

Addresses Issue #464. 

## Changes

Removed the sh dependency in requirements.txt and its usage in doc/conf.py: `subprocess.call(["sh", "./docbuild.sh"])`. 

