### PR TITLE
FIX-#464: Remove sh dependency

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,16 +18,18 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-import subprocess
+# import subprocess
 
 # subprocess.call(["sh", "./docbuild.sh"])
+import os
+
+os.system("sh ./docbuild.sh")
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,9 +18,7 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# import subprocess
 
-# subprocess.call(["sh", "./docbuild.sh"])
 import os
 
 os.system("sh ./docbuild.sh")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,7 @@
 
 import subprocess
 
-subprocess.call(["sh", "./docbuild.sh"])
+# subprocess.call(["sh", "./docbuild.sh"])
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ lux-widget>=0.1.4
 autopep8>=1.5
 iso3166
 psutil>=5.9.0
-# sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ lux-widget>=0.1.4
 autopep8>=1.5
 iso3166
 psutil>=5.9.0
-sh
+# sh


### PR DESCRIPTION
Signed-off-by: Labanya Mukhopadhyay <labanya@ponder.io>

## Overview

Addresses Issue #464.

## Changes

Removed the sh dependency in requirements.txt and its usage in doc/conf.py: `subprocess.call(["sh", "./docbuild.sh"])`.