### PR TITLE
FEAT-#497 Reproducible.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:22.04
+
+WORKDIR /app/
+
+# Locale
+RUN apt-get update && \
+    apt-get install -y locales && \
+    rm -rf /var/lib/apt/lists/* && \
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+# For Python3
+RUN apt-get update && \
+    apt-get install -y software-properties-common
+RUN add-apt-repository universe
+RUN apt-get update && \
+    apt-get install -y wget && \
+    apt-get install -y python3
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
+RUN rm get-pip.py
+
+# Lux Tools
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install -r /app/requirements.txt
+RUN pip install jupyter
+RUN jupyter nbextension install --py luxwidget
+RUN jupyter nbextension enable --py luxwidget
+
+# Lux
+COPY ./lux/ /app/lux/
+COPY ./setup.py /app/setup.py
+COPY ./setup.cfg /app/setup.cfg
+COPY ./README.md /app/README.md
+RUN pip install -e /app/
+
+EXPOSE 8888
+WORKDIR /
+CMD [ "jupyter", "notebook", "--port=8888", "--no-browser", "--ip=0.0.0.0", "--allow-root" ]

--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ Note that JupyterLab and VSCode is supported only for lux-widget version >=0.1.2
 
 If you encounter issues with the installation, please refer to [this page](https://lux-api.readthedocs.io/en/latest/source/guide/FAQ.html#troubleshooting-tips) to troubleshoot the installation. Follow [these instructions](https://lux-api.readthedocs.io/en/latest/source/getting_started/installation.html#manual-installation-dev-setup) to set up Lux for development purposes.
 
+# Setup with Docker
+
+Alternatively, if you would like to install and run a local jupypter notebook server on docker, use the following command:
+
+```
+docker compose up
+```
+
+or build the image yourself:
+
+```
+docker build -t lux .
+```
+
+and run it:
+
+```
+docker run lux
+```
+
 # Support and Resources
 
 Lux is undergoing active development. If you are using Lux, we would love to hear from you! 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  notebook:
+    build:
+      dockerfile: Dockerfile
+    ports:
+      - "8888:8888"


### PR DESCRIPTION
Using 🐋 containers s.t. to provide builds that are compatible with both pandas 1.5 and pandas 2.0.

## Overview

Added docker container that works with pandas 1.5 and 2.0.

## Changes

Added docker file.

## Example Output

None.